### PR TITLE
Make minitests work again

### DIFF
--- a/spec/vcloud_director/spec_helper.rb
+++ b/spec/vcloud_director/spec_helper.rb
@@ -1,3 +1,5 @@
+require "fog/vcloud_director"
+
 if ENV["FOG_MOCK"] == "true"
   Fog.mock!
 end


### PR DESCRIPTION
With this commit we add missing import that prevented minitests from running since fog/core was not loaded so methods were missing on Fog module.