### PR TITLE
Enhance instantiate vApp from template API call

### DIFF
--- a/spec/vcloud_director/generators/compute/compose_common_spec.rb
+++ b/spec/vcloud_director/generators/compute/compose_common_spec.rb
@@ -1,0 +1,72 @@
+require './spec/vcloud_director/spec_helper.rb'
+require 'minitest/autorun'
+require 'nokogiri'
+require './lib/fog/vcloud_director/generators/compute/compose_common.rb'
+
+include Fog::Generators::Compute::VcloudDirector::ComposeCommon
+
+describe Fog::Generators::Compute::VcloudDirector::ComposeCommon do
+  describe '.calculate_fence_mode' do
+    [
+      {
+        :case        => 'default',
+        :mode        => nil,
+        :parent      => nil,
+        :parent_name => nil,
+        :expected    => 'isolated'
+      },
+      {
+        :case        => 'prevent isolated when parent',
+        :mode        => 'isolated',
+        :parent      => 'parent-id',
+        :parent_name => nil,
+        :expected    => 'bridged'
+      },
+      {
+        :case        => 'keep natRouted when parent',
+        :mode        => 'natRouted',
+        :parent      => 'parent-id',
+        :parent_name => nil,
+        :expected    => 'natRouted'
+      },
+      {
+        :case        => 'keep bridged when parent',
+        :mode        => 'bridged',
+        :parent      => 'parent-id',
+        :parent_name => nil,
+        :expected    => 'bridged'
+      },
+      {
+        :case        => 'prevent bridged when no parent',
+        :mode        => 'bridged',
+        :parent      => nil,
+        :parent_name => nil,
+        :expected    => 'isolated'
+      },
+      {
+        :case        => 'prevent natRouted when no parent',
+        :mode        => 'natRouted',
+        :parent      => nil,
+        :parent_name => nil,
+        :expected    => 'isolated'
+      },
+      {
+        :case        => 'prevent isolated when parent_name',
+        :mode        => 'isolated',
+        :parent      => nil,
+        :parent_name => 'parent-name',
+        :expected    => 'bridged'
+      },
+    ].each do |args|
+      it args[:case].to_s do
+        mode = Fog::Generators::Compute::VcloudDirector::ComposeCommon.send(
+          :calculate_fence_mode,
+          args[:mode],
+          args[:parent],
+          args[:parent_name]
+        )
+        mode.must_equal(args[:expected])
+      end
+    end
+  end
+end


### PR DESCRIPTION
With this commit we allow user to customize vapp networks when instatntiating vapp template. Following format is used:

```ruby
:vapp_networks => [
  {
    :name        => 'network',
    :description => 'VM Network Description',
    :deployed    => true,
    :parent      => 'parent-network-id',
    :fence_mode  => 'bridged',
    :retain      => false,
    :external_ip => '17.17.17.17',
    :subnet      => [
      {
        :enabled    => true,
        :inherited  => false,
        :gateway    => '1.2.3.4',
        :netmask    => '255.255.255.0',
        :dns1       => '5.6.7.8',
        :dns2       => '9.10.11.12',
        :dns_suffix => 'dns-suffix',
        :ip_range   => [{ :start => '192.168.254.100', :end => '192.168.254.199' }]
      }
    ]
  }
]
```

Small portion of this functionality was already present, but in a different format (by passing `:InstantiationParams`) and for compatibility reasons we now support both of them (only one at a time).
