### PR TITLE
Centralize code imports into lib/fog/vcloud_director.rb

### DIFF
--- a/lib/fog/vcloud_director.rb
+++ b/lib/fog/vcloud_director.rb
@@ -1,2 +1,15 @@
-require 'fog/vcloud_director/compute'
+require 'pp'
 require 'securerandom'
+
+require 'fog/core'
+require 'fog/core/model'
+require 'fog/core/collection'
+require 'fog/xml'
+require 'fog/vcloud_director/core'
+require 'fog/vcloud_director/query'
+require 'fog/vcloud_director/compute'
+
+Dir['./lib/fog/vcloud_director/generators/**/*.rb'].each {|file| require file }
+Dir['./lib/fog/vcloud_director/models/**/*.rb'].each {|file| require file }
+Dir['./lib/fog/vcloud_director/parsers/**/*.rb'].each {|file| require file }
+Dir['./lib/fog/vcloud_director/requests/**/*.rb'].each {|file| require file }

--- a/lib/fog/vcloud_director/compute.rb
+++ b/lib/fog/vcloud_director/compute.rb
@@ -1,6 +1,3 @@
-require 'fog/vcloud_director/core'
-require 'fog/vcloud_director/query'
-
 class VcloudDirectorParser < Fog::Parsers::Base
   def extract_attributes(attributes_xml)
     attributes = {}

--- a/lib/fog/vcloud_director/core.rb
+++ b/lib/fog/vcloud_director/core.rb
@@ -1,6 +1,3 @@
-require 'fog/core'
-require 'fog/xml'
-
 module Fog
   module VcloudDirector
     extend Fog::Provider

--- a/lib/fog/vcloud_director/models/compute/catalog.rb
+++ b/lib/fog/vcloud_director/models/compute/catalog.rb
@@ -1,5 +1,3 @@
-require 'fog/core/model'
-
 module Fog
   module Compute
     class VcloudDirector

--- a/lib/fog/vcloud_director/models/compute/catalog_item.rb
+++ b/lib/fog/vcloud_director/models/compute/catalog_item.rb
@@ -1,5 +1,3 @@
-require 'fog/core/model'
-
 module Fog
   module Compute
     class VcloudDirector

--- a/lib/fog/vcloud_director/models/compute/catalog_items.rb
+++ b/lib/fog/vcloud_director/models/compute/catalog_items.rb
@@ -1,4 +1,3 @@
-require 'fog/core/collection'
 require 'fog/vcloud_director/models/compute/catalog_item'
 
 module Fog

--- a/lib/fog/vcloud_director/models/compute/catalogs.rb
+++ b/lib/fog/vcloud_director/models/compute/catalogs.rb
@@ -1,4 +1,3 @@
-require 'fog/core/collection'
 require 'fog/vcloud_director/models/compute/catalog'
 require 'fog/vcloud_director/models/compute/catalog_item'
 

--- a/lib/fog/vcloud_director/models/compute/custom_field.rb
+++ b/lib/fog/vcloud_director/models/compute/custom_field.rb
@@ -1,5 +1,3 @@
-require 'fog/core/model'
-
 module Fog
   module Compute
     class VcloudDirector

--- a/lib/fog/vcloud_director/models/compute/disk.rb
+++ b/lib/fog/vcloud_director/models/compute/disk.rb
@@ -1,5 +1,3 @@
-require 'fog/core/model'
-
 module Fog
   module Compute
     class VcloudDirector

--- a/lib/fog/vcloud_director/models/compute/disks.rb
+++ b/lib/fog/vcloud_director/models/compute/disks.rb
@@ -1,4 +1,3 @@
-require 'fog/core/collection'
 require 'fog/vcloud_director/models/compute/disk'
 
 module Fog

--- a/lib/fog/vcloud_director/models/compute/media.rb
+++ b/lib/fog/vcloud_director/models/compute/media.rb
@@ -1,5 +1,3 @@
-require 'fog/core/model'
-
 module Fog
   module Compute
     class VcloudDirector

--- a/lib/fog/vcloud_director/models/compute/medias.rb
+++ b/lib/fog/vcloud_director/models/compute/medias.rb
@@ -1,4 +1,3 @@
-require 'fog/core/collection'
 require 'fog/vcloud_director/models/compute/media'
 
 module Fog

--- a/lib/fog/vcloud_director/models/compute/network.rb
+++ b/lib/fog/vcloud_director/models/compute/network.rb
@@ -1,5 +1,3 @@
-require 'fog/core/model'
-
 module Fog
   module Compute
     class VcloudDirector

--- a/lib/fog/vcloud_director/models/compute/networks.rb
+++ b/lib/fog/vcloud_director/models/compute/networks.rb
@@ -1,4 +1,3 @@
-require 'fog/core/collection'
 require 'fog/vcloud_director/models/compute/network'
 
 module Fog

--- a/lib/fog/vcloud_director/models/compute/organization.rb
+++ b/lib/fog/vcloud_director/models/compute/organization.rb
@@ -1,5 +1,3 @@
-require 'fog/core/model'
-
 module Fog
   module Compute
     class VcloudDirector

--- a/lib/fog/vcloud_director/models/compute/organizations.rb
+++ b/lib/fog/vcloud_director/models/compute/organizations.rb
@@ -1,4 +1,3 @@
-require 'fog/core/collection'
 require 'fog/vcloud_director/models/compute/organization'
 
 module Fog

--- a/lib/fog/vcloud_director/models/compute/tag.rb
+++ b/lib/fog/vcloud_director/models/compute/tag.rb
@@ -1,5 +1,3 @@
-require 'fog/core/model'
-
 module Fog
   module Compute
     class VcloudDirector

--- a/lib/fog/vcloud_director/models/compute/tags.rb
+++ b/lib/fog/vcloud_director/models/compute/tags.rb
@@ -1,4 +1,3 @@
-require 'fog/core/collection'
 require 'fog/vcloud_director/models/compute/tag'
 
 module Fog

--- a/lib/fog/vcloud_director/models/compute/task.rb
+++ b/lib/fog/vcloud_director/models/compute/task.rb
@@ -1,5 +1,3 @@
-require 'fog/core/model'
-
 module Fog
   module Compute
     class VcloudDirector

--- a/lib/fog/vcloud_director/models/compute/tasks.rb
+++ b/lib/fog/vcloud_director/models/compute/tasks.rb
@@ -1,4 +1,3 @@
-require 'fog/core/collection'
 require 'fog/vcloud_director/models/compute/task'
 
 module Fog

--- a/lib/fog/vcloud_director/models/compute/template_vm.rb
+++ b/lib/fog/vcloud_director/models/compute/template_vm.rb
@@ -1,4 +1,3 @@
-require 'fog/core/model'
 require 'fog/vcloud_director/models/compute/vm_customization'
 
 module Fog

--- a/lib/fog/vcloud_director/models/compute/template_vms.rb
+++ b/lib/fog/vcloud_director/models/compute/template_vms.rb
@@ -1,4 +1,3 @@
-require 'fog/core/collection'
 require 'fog/vcloud_director/models/compute/template_vm'
 
 module Fog

--- a/lib/fog/vcloud_director/models/compute/vapp.rb
+++ b/lib/fog/vcloud_director/models/compute/vapp.rb
@@ -1,5 +1,3 @@
-require 'fog/core/model'
-
 module Fog
   module Compute
     class VcloudDirector

--- a/lib/fog/vcloud_director/models/compute/vapp_template.rb
+++ b/lib/fog/vcloud_director/models/compute/vapp_template.rb
@@ -1,5 +1,3 @@
-require 'fog/core/model'
-
 module Fog
   module Compute
     class VcloudDirector

--- a/lib/fog/vcloud_director/models/compute/vapp_templates.rb
+++ b/lib/fog/vcloud_director/models/compute/vapp_templates.rb
@@ -1,4 +1,3 @@
-require 'fog/core/collection'
 require 'fog/vcloud_director/models/compute/vapp'
 
 module Fog

--- a/lib/fog/vcloud_director/models/compute/vapps.rb
+++ b/lib/fog/vcloud_director/models/compute/vapps.rb
@@ -1,4 +1,3 @@
-require 'fog/core/collection'
 require 'fog/vcloud_director/models/compute/vapp'
 
 module Fog

--- a/lib/fog/vcloud_director/models/compute/vdc.rb
+++ b/lib/fog/vcloud_director/models/compute/vdc.rb
@@ -1,5 +1,3 @@
-require 'fog/core/model'
-
 module Fog
   module Compute
     class VcloudDirector

--- a/lib/fog/vcloud_director/models/compute/vdcs.rb
+++ b/lib/fog/vcloud_director/models/compute/vdcs.rb
@@ -1,4 +1,3 @@
-require 'fog/core/collection'
 require 'fog/vcloud_director/models/compute/vdc'
 
 module Fog

--- a/lib/fog/vcloud_director/models/compute/vm.rb
+++ b/lib/fog/vcloud_director/models/compute/vm.rb
@@ -1,4 +1,3 @@
-require 'fog/core/model'
 require 'fog/vcloud_director/models/compute/vm_customization'
 
 module Fog

--- a/lib/fog/vcloud_director/models/compute/vm_customization.rb
+++ b/lib/fog/vcloud_director/models/compute/vm_customization.rb
@@ -1,5 +1,3 @@
-require 'fog/core/model'
-
 module Fog
   module Compute
     class VcloudDirector

--- a/lib/fog/vcloud_director/models/compute/vm_customizations.rb
+++ b/lib/fog/vcloud_director/models/compute/vm_customizations.rb
@@ -1,4 +1,3 @@
-require 'fog/core/collection'
 require 'fog/vcloud_director/models/compute/vm_customization'
 
 module Fog

--- a/lib/fog/vcloud_director/models/compute/vm_network.rb
+++ b/lib/fog/vcloud_director/models/compute/vm_network.rb
@@ -1,5 +1,3 @@
-require 'fog/core/model'
-
 module Fog
   module Compute
     class VcloudDirector

--- a/lib/fog/vcloud_director/models/compute/vm_networks.rb
+++ b/lib/fog/vcloud_director/models/compute/vm_networks.rb
@@ -1,4 +1,3 @@
-require 'fog/core/collection'
 require 'fog/vcloud_director/models/compute/vm_network'
 
 module Fog

--- a/lib/fog/vcloud_director/models/compute/vms.rb
+++ b/lib/fog/vcloud_director/models/compute/vms.rb
@@ -1,4 +1,3 @@
-require 'fog/core/collection'
 require 'fog/vcloud_director/models/compute/vm'
 
 module Fog

--- a/lib/fog/vcloud_director/query.rb
+++ b/lib/fog/vcloud_director/query.rb
@@ -1,4 +1,3 @@
-require 'pp'
 module Fog
   module VcloudDirector
     module Query

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,3 +6,5 @@ require "mocha/minitest"
 $LOAD_PATH.unshift "lib"
 
 require "fog/vcloud_director"
+
+include Fog::Generators::Compute::VcloudDirector::ComposeCommon

--- a/spec/vcloud_director/generators/compute/compose_common_spec.rb
+++ b/spec/vcloud_director/generators/compute/compose_common_spec.rb
@@ -1,9 +1,4 @@
 require './spec/spec_helper.rb'
-require 'minitest/autorun'
-require 'nokogiri'
-require './lib/fog/vcloud_director/generators/compute/compose_common.rb'
-
-include Fog::Generators::Compute::VcloudDirector::ComposeCommon
 
 describe Fog::Generators::Compute::VcloudDirector::ComposeCommon do
   describe '.calculate_fence_mode' do

--- a/spec/vcloud_director/generators/compute/compose_vapp_spec.rb
+++ b/spec/vcloud_director/generators/compute/compose_vapp_spec.rb
@@ -1,8 +1,4 @@
 require './spec/spec_helper.rb'
-require './lib/fog/vcloud_director/generators/compute/compose_common.rb'
-require './lib/fog/vcloud_director/generators/compute/compose_vapp.rb'
-
-include Fog::Generators::Compute::VcloudDirector::ComposeCommon
 
 describe Fog::Generators::Compute::VcloudDirector::ComposeVapp do
   describe '.calculate_fence_mode' do

--- a/spec/vcloud_director/generators/compute/create_snapshot_spec.rb
+++ b/spec/vcloud_director/generators/compute/create_snapshot_spec.rb
@@ -1,0 +1,4 @@
+require './spec/spec_helper.rb'
+
+describe Fog::Generators::Compute::VcloudDirector::CreateSnapshot do
+end

--- a/spec/vcloud_director/generators/compute/customization_spec.rb
+++ b/spec/vcloud_director/generators/compute/customization_spec.rb
@@ -1,0 +1,4 @@
+require './spec/spec_helper.rb'
+
+describe Fog::Generators::Compute::VcloudDirector::Customization do
+end

--- a/spec/vcloud_director/generators/compute/disks_spec.rb
+++ b/spec/vcloud_director/generators/compute/disks_spec.rb
@@ -1,0 +1,4 @@
+require './spec/spec_helper.rb'
+
+describe Fog::Generators::Compute::VcloudDirector::Disks do
+end

--- a/spec/vcloud_director/generators/compute/edge_gateway_service_configuration_spec.rb
+++ b/spec/vcloud_director/generators/compute/edge_gateway_service_configuration_spec.rb
@@ -1,0 +1,4 @@
+require './spec/spec_helper.rb'
+
+describe Fog::Generators::Compute::VcloudDirector::EdgeGatewayServiceConfiguration do
+end

--- a/spec/vcloud_director/generators/compute/instantiate_vapp_template_params_spec.rb
+++ b/spec/vcloud_director/generators/compute/instantiate_vapp_template_params_spec.rb
@@ -1,7 +1,4 @@
 require './spec/spec_helper.rb'
-require 'minitest/autorun'
-require 'nokogiri'
-require './lib/fog/vcloud_director/generators/compute/instantiate_vapp_template_params.rb'
 
 describe Fog::Generators::Compute::VcloudDirector::InstantiateVappTemplateParams do
   describe 'Complete xml' do

--- a/spec/vcloud_director/generators/compute/metadata_spec.rb
+++ b/spec/vcloud_director/generators/compute/metadata_spec.rb
@@ -1,0 +1,4 @@
+require './spec/spec_helper.rb'
+
+describe Fog::Generators::Compute::VcloudDirector::MetadataBase do
+end

--- a/spec/vcloud_director/generators/compute/org_vdc_network_spec.rb
+++ b/spec/vcloud_director/generators/compute/org_vdc_network_spec.rb
@@ -1,0 +1,4 @@
+require './spec/spec_helper.rb'
+
+describe Fog::Generators::Compute::VcloudDirector::OrgVdcNetwork do
+end

--- a/spec/vcloud_director/generators/compute/recompose_vapp_spec.rb
+++ b/spec/vcloud_director/generators/compute/recompose_vapp_spec.rb
@@ -1,0 +1,4 @@
+require './spec/spec_helper.rb'
+
+describe Fog::Generators::Compute::VcloudDirector::RecomposeVapp do
+end

--- a/spec/vcloud_director/generators/compute/vapp_spec.rb
+++ b/spec/vcloud_director/generators/compute/vapp_spec.rb
@@ -1,0 +1,4 @@
+require './spec/spec_helper.rb'
+
+describe Fog::Generators::Compute::VcloudDirector::Vapp do
+end

--- a/spec/vcloud_director/generators/compute/vm_network_spec.rb
+++ b/spec/vcloud_director/generators/compute/vm_network_spec.rb
@@ -1,0 +1,4 @@
+require './spec/spec_helper.rb'
+
+describe Fog::Generators::Compute::VcloudDirector::VmNetwork do
+end

--- a/spec/vcloud_director/generators/compute/vm_spec.rb
+++ b/spec/vcloud_director/generators/compute/vm_spec.rb
@@ -1,0 +1,4 @@
+require './spec/spec_helper.rb'
+
+describe Fog::Generators::Compute::VcloudDirector::Vm do
+end

--- a/spec/vcloud_director/models/compute/basic_spec.rb
+++ b/spec/vcloud_director/models/compute/basic_spec.rb
@@ -1,5 +1,4 @@
 require './spec/spec_helper.rb'
-Dir['./lib/fog/vcloud_director/models/**/*.rb'].each {|file| require file }
 
 describe Fog::Compute::VcloudDirector do
   describe 'No load errors' do

--- a/spec/vcloud_director/parsers/compute/disks_spec.rb
+++ b/spec/vcloud_director/parsers/compute/disks_spec.rb
@@ -1,0 +1,4 @@
+require './spec/spec_helper.rb'
+
+describe Fog::Parsers::Compute::VcloudDirector::Disks do
+end

--- a/spec/vcloud_director/parsers/compute/metadata_spec.rb
+++ b/spec/vcloud_director/parsers/compute/metadata_spec.rb
@@ -1,0 +1,4 @@
+require './spec/spec_helper.rb'
+
+describe Fog::Parsers::Compute::VcloudDirector::Metadata do
+end

--- a/spec/vcloud_director/parsers/compute/network_spec.rb
+++ b/spec/vcloud_director/parsers/compute/network_spec.rb
@@ -1,0 +1,4 @@
+require './spec/spec_helper.rb'
+
+describe Fog::Parsers::Compute::VcloudDirector::Network do
+end

--- a/spec/vcloud_director/parsers/compute/vm_customization_spec.rb
+++ b/spec/vcloud_director/parsers/compute/vm_customization_spec.rb
@@ -1,0 +1,4 @@
+require './spec/spec_helper.rb'
+
+describe Fog::Parsers::Compute::VcloudDirector::VmCustomization do
+end

--- a/spec/vcloud_director/parsers/compute/vm_network_spec.rb
+++ b/spec/vcloud_director/parsers/compute/vm_network_spec.rb
@@ -1,0 +1,4 @@
+require './spec/spec_helper.rb'
+
+describe Fog::Parsers::Compute::VcloudDirector::VmNetwork do
+end

--- a/spec/vcloud_director/parsers/compute/vm_parser_helper_spec.rb
+++ b/spec/vcloud_director/parsers/compute/vm_parser_helper_spec.rb
@@ -1,0 +1,4 @@
+require './spec/spec_helper.rb'
+
+describe Fog::Parsers::Compute::VcloudDirector::VmParserHelper do
+end

--- a/spec/vcloud_director/parsers/compute/vm_spec.rb
+++ b/spec/vcloud_director/parsers/compute/vm_spec.rb
@@ -1,0 +1,4 @@
+require './spec/spec_helper.rb'
+
+describe Fog::Parsers::Compute::VcloudDirector::Vm do
+end

--- a/spec/vcloud_director/parsers/compute/vms_by_metadata_spec.rb
+++ b/spec/vcloud_director/parsers/compute/vms_by_metadata_spec.rb
@@ -1,0 +1,4 @@
+require './spec/spec_helper.rb'
+
+describe Fog::Parsers::Compute::VcloudDirector::VmsByMetadata do
+end

--- a/spec/vcloud_director/parsers/compute/vms_spec.rb
+++ b/spec/vcloud_director/parsers/compute/vms_spec.rb
@@ -1,0 +1,4 @@
+require './spec/spec_helper.rb'
+
+describe Fog::Parsers::Compute::VcloudDirector::Vms do
+end

--- a/spec/vcloud_director/requests/compute/basic_spec.rb
+++ b/spec/vcloud_director/requests/compute/basic_spec.rb
@@ -1,5 +1,4 @@
 require './spec/spec_helper.rb'
-Dir['./lib/fog/vcloud_director/requests/**/*.rb'].each {|file| require file }
 
 describe Fog::Compute::VcloudDirector::Real do
   describe 'Requests exist' do

--- a/spec/vcloud_director/requests/compute/instantiate_vapp_template_spec.rb
+++ b/spec/vcloud_director/requests/compute/instantiate_vapp_template_spec.rb
@@ -1,6 +1,4 @@
 require './spec/spec_helper.rb'
-require 'minitest/autorun'
-require './lib/fog/vcloud_director/requests/compute/instantiate_vapp_template.rb'
 
 describe Fog::Compute::VcloudDirector::Real do
   before do


### PR DESCRIPTION
With this commit we do following:

1) Import all project files in top-level class so that users and unit tests only need to 
```require 'fog/vcloud_director'``` and not each file separately.
2) Remove imports from lower-level classes/modules
