### PR TITLE
Shift default API version from 5.1 -> 5.5

### DIFF
--- a/lib/fog/vcloud_director/compute.rb
+++ b/lib/fog/vcloud_director/compute.rb
@@ -29,7 +29,7 @@ module Fog
         PATH        = '/api'
         PORT        = 443
         SCHEME      = 'https'
-        API_VERSION = '5.1'
+        API_VERSION = '5.5'
         OMIT_DEFAULT_PORT = true
       end
 


### PR DESCRIPTION
With this commit we shift default version which is only used when client program doesn't specify it manually with:

```ruby
service = Fog::Compute::VcloudDirector.new(
  ... # other options
  :vcloud_director_api_version => '9.0'
)
```

Raising default version makes sense now that we've introduced an API call `post_acquire_mks_ticket` which returns empty response when invoked with API version less than 5.5.