### PR TITLE
Whitelist `port` argument to avoid warnings

### DIFF
--- a/lib/fog/vcloud_director/compute.rb
+++ b/lib/fog/vcloud_director/compute.rb
@@ -45,7 +45,7 @@ module Fog
       class TaskError < Fog::VcloudDirector::Errors::TaskError; end
 
       requires :vcloud_director_username, :vcloud_director_password, :vcloud_director_host
-      recognizes :vcloud_director_api_version, :vcloud_director_show_progress, :path, :vcloud_token
+      recognizes :vcloud_director_api_version, :vcloud_director_show_progress, :path, :vcloud_token, :port
 
       secrets :vcloud_director_password
 


### PR DESCRIPTION
Following warning was being reported everytime our gem was initialized:

```
[fog][WARNING] Unrecognized arguments: port
```

Knowing that our gem actually uses `port` argument, the warning renders to be quite annoying. With this commit we register it with list of expected arguments and the warning no longer appears.