### PR TITLE
Support passing custom parser

### DIFF
--- a/lib/fog/vcloud_director/requests/compute/get_vapp.rb
+++ b/lib/fog/vcloud_director/requests/compute/get_vapp.rb
@@ -5,20 +5,21 @@ module Fog
         # Retrieve a vApp or VM.
         #
         # @param [String] id Object identifier of the vApp or VM.
+        # @param [Class or Symbol] parser, see compute.rb#request() documentation for details.
         # @return [Excon::Response]
         #   * body<~Hash>:
         #
         # @see http://pubs.vmware.com/vcd-51/topic/com.vmware.vcloud.api.reference.doc_51/doc/operations/GET-VApp.html
         # @since vCloud API version 0.9
-        def get_vapp(id)
+        def get_vapp(id, parser: Fog::ToHashDocument)
           response = request(
             :expects    => 200,
             :idempotent => true,
             :method     => 'GET',
-            :parser     => Fog::ToHashDocument.new,
+            :parser     => parser,
             :path       => "vApp/#{id}"
           )
-          ensure_list! response.body, :Children, :Vm
+          ensure_list!(response.body, :Children, :Vm) if parser == Fog::ToHashDocument
           response
         end
       end


### PR DESCRIPTION
With this commit we allow user to pass custom SAX parser implementation to the `request()` call. Furthermore, we support two special parsers:

- `plaintext` - return plaintext XML response. Until now   ToHashDocument parser was always used which prevented user   from getting the actual XML string.
- `xml` - return DOM-parsed XML response. This is an upgrade of  `plaintext` option to make it more user-friendly.

Reason for such change is that RECONFIGURE requests rely on whole XML sections being sent in body, even if we're not modifying them. Therefore we need to be able to first obtain current XML description of the VM to then only modify desired subsections.