### PR TITLE
Support virtual hardware reconfiguration for VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -961,3 +961,6 @@ template.instantiate('webserver', {
 ```
 
 See [here](./docs/examples-vapp-instantiate.md) for real-world example.
+
+### Reconfigure VM Virtual Hardware
+See [here](./docs/examples-vm-reconfigure.md) for real-world example.

--- a/docs/examples-vm-reconfigure.md
+++ b/docs/examples-vm-reconfigure.md
@@ -1,0 +1,39 @@
+# VM Reconfiguration Examples
+In this document we provide examples of VM reconfiguration.
+
+## Hardware Reconfiguration Example
+This example demonstrates basic hardware customization parameters. Raw content of parameter
+`xml` can be examined [here](./vm-to-reconfigure.xml).
+
+```ruby
+service = Fog::Compute::VcloudDirector.new(...)
+
+# Obtain nokogiri-parsed XML representation of VM.
+xml = service.get_vapp('vm-8dc9990c-a55a-418e-8e21-5942a20b93ef', :parser => 'xml').body
+
+# Decide what hardware options to customize.
+options = {
+    :name        => 'DB VM',                           # new VM name
+    :description => 'Some Description',                # new VM description
+    :hardware    => {
+        :memory => { :quantity_mb => 4096 },           # set memory to 4GB
+        :cpu    => { :num_cores => 4, :cores_per_socket => 1 },
+        :disk   => [
+            { :id => '2000', :capacity_mb => 5*1024 }, # increase disk 2000 to 5GB
+            { :id => '2001', :capacity_mb => -1 },     # delete disk 2001
+            { :capacity_mb => 1*1024 }                 # add a new disk of size 1GB
+        ]
+    }
+}
+
+# Actually perform customization.
+service.post_reconfigure_vm(
+  'vm-8dc9990c-a55a-418e-8e21-5942a20b93ef',
+  xml,
+  options
+)
+``` 
+
+**NOTE**: If you omit `:hardware` key from options, then reconfiguration request will be
+simplified by omitting entire VirtualHardwareSection from payload XML. So please prefer
+omitting the `:hardware` key over passing `:hardware => {}` in order to reduce network load. 

--- a/docs/vm-to-reconfigure.xml
+++ b/docs/vm-to-reconfigure.xml
@@ -1,0 +1,373 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Vm xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" needsCustomization="false" nestedHypervisorEnabled="false" deployed="false" status="8" name="Databasy Machiny" id="urn:vcloud:vm:8dc9990c-a55a-418e-8e21-5942a20b93ef" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef" type="application/vnd.vmware.vcloud.vm+xml">
+  <Link rel="power:powerOn" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/power/action/powerOn" />
+  <Link rel="deploy" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml" />
+  <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef" type="application/vnd.vmware.vcloud.vm+xml" />
+  <Link rel="remove" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef" />
+  <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/metadata" type="application/vnd.vmware.vcloud.metadata+xml" />
+  <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/productSections/" type="application/vnd.vmware.vcloud.productSections+xml" />
+  <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/metrics/historic" type="application/vnd.vmware.vcloud.metrics.historicUsageSpec+xml" />
+  <Link rel="metrics" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/metrics/historic" type="application/vnd.vmware.vcloud.metrics.historicUsageSpec+xml" />
+  <Link rel="screen:thumbnail" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/screen" />
+  <Link rel="media:insertMedia" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/media/action/insertMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml" />
+  <Link rel="media:ejectMedia" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/media/action/ejectMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml" />
+  <Link rel="disk:attach" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/disk/action/attach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml" />
+  <Link rel="disk:detach" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/disk/action/detach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml" />
+  <Link rel="enable" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/action/enableNestedHypervisor" />
+  <Link rel="customizeAtNextPowerOn" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/action/customizeAtNextPowerOn" />
+  <Link rel="snapshot:create" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml" />
+  <Link rel="reconfigureVm" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/action/reconfigureVm" name="Databasy Machiny" type="application/vnd.vmware.vcloud.vm+xml" />
+  <Link rel="up" href="https://10.12.0.18/api/vApp/vapp-fe8d013d-dd2f-4ac6-9e8a-3a4a18e0a62e" type="application/vnd.vmware.vcloud.vApp+xml" />
+  <Description />
+  <Tasks>
+    <Task cancelRequested="false" endTime="2018-04-18T11:08:40.855+02:00" expiryTime="2018-07-17T11:08:38.285+02:00" operation="Updated Virtual Machine Databasy Machiny(8dc9990c-a55a-418e-8e21-5942a20b93ef)" operationName="vappUpdateVm" serviceNamespace="com.vmware.vcloud" startTime="2018-04-18T11:08:38.285+02:00" status="error" name="task" id="urn:vcloud:task:cc74e25c-c52f-40f7-930b-eae865103e08" href="https://10.12.0.18/api/task/cc74e25c-c52f-40f7-930b-eae865103e08" type="application/vnd.vmware.vcloud.task+xml">
+      <Owner href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef" name="Databasy Machiny" type="application/vnd.vmware.vcloud.vm+xml" />
+      <Error majorErrorCode="500" message="[ 24e09aac-f47d-4bfa-853d-2512d9eaeb7c ] Unable to perform this action. Contact your cloud administrator." minorErrorCode="INTERNAL_SERVER_ERROR" />
+      <User href="https://10.12.0.18/api/admin/user/e0d6e74d-efde-49fe-b19f-ace7e55b68dd" name="redhat" type="application/vnd.vmware.admin.user+xml" />
+      <Organization href="https://10.12.0.18/api/org/8f03aa58-b618-4c32-836b-dc6b612ed3a4" name="RedHat" type="application/vnd.vmware.vcloud.org+xml" />
+      <Details>[ 24e09aac-f47d-4bfa-853d-2512d9eaeb7c ] Unable to perform this action. Contact your cloud administr...</Details>
+    </Task>
+    <Task cancelRequested="false" endTime="2018-04-18T11:25:32.888+02:00" expiryTime="2018-07-17T11:25:29.954+02:00" operation="Updated Virtual Machine Databasy Machiny(8dc9990c-a55a-418e-8e21-5942a20b93ef)" operationName="vappUpdateVm" serviceNamespace="com.vmware.vcloud" startTime="2018-04-18T11:25:29.954+02:00" status="error" name="task" id="urn:vcloud:task:fb2fb286-42f2-4320-9ddf-41c7a7ea2a6c" href="https://10.12.0.18/api/task/fb2fb286-42f2-4320-9ddf-41c7a7ea2a6c" type="application/vnd.vmware.vcloud.task+xml">
+      <Owner href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef" name="Databasy Machiny" type="application/vnd.vmware.vcloud.vm+xml" />
+      <Error majorErrorCode="500" message="[ 589e08cd-f44b-4a4d-97dc-ea4005b6ec7a ] Unable to perform this action. Contact your cloud administrator." minorErrorCode="INTERNAL_SERVER_ERROR" />
+      <User href="https://10.12.0.18/api/admin/user/e0d6e74d-efde-49fe-b19f-ace7e55b68dd" name="redhat" type="application/vnd.vmware.admin.user+xml" />
+      <Organization href="https://10.12.0.18/api/org/8f03aa58-b618-4c32-836b-dc6b612ed3a4" name="RedHat" type="application/vnd.vmware.vcloud.org+xml" />
+      <Details>[ 589e08cd-f44b-4a4d-97dc-ea4005b6ec7a ] Unable to perform this action. Contact your cloud administr...</Details>
+    </Task>
+    <Task cancelRequested="false" endTime="2018-04-18T11:29:30.917+02:00" expiryTime="2018-07-17T11:29:27.536+02:00" operation="Updated Virtual Machine Databasy Machiny(8dc9990c-a55a-418e-8e21-5942a20b93ef)" operationName="vappUpdateVm" serviceNamespace="com.vmware.vcloud" startTime="2018-04-18T11:29:27.536+02:00" status="error" name="task" id="urn:vcloud:task:b47e437f-b159-4069-afc4-5c5f347013f0" href="https://10.12.0.18/api/task/b47e437f-b159-4069-afc4-5c5f347013f0" type="application/vnd.vmware.vcloud.task+xml">
+      <Owner href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef" name="Databasy Machiny" type="application/vnd.vmware.vcloud.vm+xml" />
+      <Error majorErrorCode="500" message="[ 1d3410f5-c6ed-4cc1-ab90-7ce1edf61de7 ] Unable to perform this action. Contact your cloud administrator." minorErrorCode="INTERNAL_SERVER_ERROR" />
+      <User href="https://10.12.0.18/api/admin/user/e0d6e74d-efde-49fe-b19f-ace7e55b68dd" name="redhat" type="application/vnd.vmware.admin.user+xml" />
+      <Organization href="https://10.12.0.18/api/org/8f03aa58-b618-4c32-836b-dc6b612ed3a4" name="RedHat" type="application/vnd.vmware.vcloud.org+xml" />
+      <Details>[ 1d3410f5-c6ed-4cc1-ab90-7ce1edf61de7 ] Unable to perform this action. Contact your cloud administr...</Details>
+    </Task>
+  </Tasks>
+  <ovf:VirtualHardwareSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ovf:transport="" ns13:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" ns13:href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/">
+    <ovf:Info>Virtual hardware requirements</ovf:Info>
+    <ovf:System>
+      <vssd:AutomaticRecoveryAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:AutomaticShutdownAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:AutomaticStartupAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:AutomaticStartupActionDelay xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:AutomaticStartupActionSequenceNumber xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:ConfigurationDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:ConfigurationFile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:ConfigurationID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:CreationTime xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:Description xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+      <vssd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:InstanceID>0</vssd:InstanceID>
+      <vssd:LogDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:RecoveryFile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:SnapshotDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:SuspendDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:SwapFileDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:VirtualSystemIdentifier>Databasy Machiny</vssd:VirtualSystemIdentifier>
+      <vssd:VirtualSystemType>vmx-13</vssd:VirtualSystemType>
+    </ovf:System>
+    <ovf:Item>
+      <rasd:Address>00:50:56:01:01:2c</rasd:Address>
+      <rasd:AddressOnParent>0</rasd:AddressOnParent>
+      <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
+      <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Connection ns13:ipAddressingMode="DHCP" ns13:primaryNetworkConnection="true">Localhost</rasd:Connection>
+      <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Description>PCNet32 ethernet adapter on "Localhost"</rasd:Description>
+      <rasd:ElementName>Network adapter 0</rasd:ElementName>
+      <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:InstanceID>1</rasd:InstanceID>
+      <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ResourceSubType>PCNet32</rasd:ResourceSubType>
+      <rasd:ResourceType>10</rasd:ResourceType>
+      <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+    </ovf:Item>
+    <ovf:Item>
+      <rasd:Address>0</rasd:Address>
+      <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Description>SCSI Controller</rasd:Description>
+      <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
+      <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:InstanceID>2</rasd:InstanceID>
+      <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
+      <rasd:ResourceType>6</rasd:ResourceType>
+      <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+    </ovf:Item>
+    <ovf:Item>
+      <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AddressOnParent>0</rasd:AddressOnParent>
+      <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Description>Hard disk</rasd:Description>
+      <rasd:ElementName>Hard disk 1</rasd:ElementName>
+      <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:HostResource ns13:storageProfileHref="https://10.12.0.18/api/vdcStorageProfile/c87b2a7c-fcab-4f8a-bef3-3ece59366c38" ns13:busType="6" ns13:busSubType="lsilogic" ns13:capacity="5120" ns13:iops="0" ns13:storageProfileOverrideVmDefault="false" />
+      <rasd:InstanceID>2000</rasd:InstanceID>
+      <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Parent>2</rasd:Parent>
+      <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ResourceType>17</rasd:ResourceType>
+      <rasd:VirtualQuantity>5368709120</rasd:VirtualQuantity>
+      <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+      <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+    </ovf:Item>
+    <ovf:Item>
+      <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AddressOnParent>2</rasd:AddressOnParent>
+      <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Description>Hard disk</rasd:Description>
+      <rasd:ElementName>Hard disk 2</rasd:ElementName>
+      <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:HostResource ns13:storageProfileHref="https://10.12.0.18/api/vdcStorageProfile/c87b2a7c-fcab-4f8a-bef3-3ece59366c38" ns13:busType="6" ns13:busSubType="lsilogic" ns13:capacity="1024" ns13:iops="0" ns13:storageProfileOverrideVmDefault="false" />
+      <rasd:InstanceID>2002</rasd:InstanceID>
+      <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Parent>2</rasd:Parent>
+      <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ResourceType>17</rasd:ResourceType>
+      <rasd:VirtualQuantity>1073741824</rasd:VirtualQuantity>
+      <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+      <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+    </ovf:Item>
+    <ovf:Item>
+      <rasd:Address>0</rasd:Address>
+      <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Description>IDE Controller</rasd:Description>
+      <rasd:ElementName>IDE Controller 0</rasd:ElementName>
+      <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:InstanceID>3</rasd:InstanceID>
+      <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ResourceType>5</rasd:ResourceType>
+      <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+    </ovf:Item>
+    <ovf:Item>
+      <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AddressOnParent>0</rasd:AddressOnParent>
+      <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+      <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Description>CD/DVD Drive</rasd:Description>
+      <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
+      <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:HostResource />
+      <rasd:InstanceID>3000</rasd:InstanceID>
+      <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Parent>3</rasd:Parent>
+      <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ResourceType>15</rasd:ResourceType>
+      <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+    </ovf:Item>
+    <ovf:Item>
+      <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AddressOnParent>0</rasd:AddressOnParent>
+      <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+      <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Description>Floppy Drive</rasd:Description>
+      <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
+      <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:HostResource />
+      <rasd:InstanceID>8000</rasd:InstanceID>
+      <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ResourceType>14</rasd:ResourceType>
+      <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+    </ovf:Item>
+    <ovf:Item ns13:type="application/vnd.vmware.vcloud.rasdItem+xml" ns13:href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/cpu">
+      <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+      <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Description>Number of Virtual CPUs</rasd:Description>
+      <rasd:ElementName>4 virtual CPU(s)</rasd:ElementName>
+      <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:InstanceID>4</rasd:InstanceID>
+      <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Reservation>0</rasd:Reservation>
+      <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ResourceType>3</rasd:ResourceType>
+      <rasd:VirtualQuantity>4</rasd:VirtualQuantity>
+      <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Weight>0</rasd:Weight>
+      <vmw:CoresPerSocket ovf:required="false">1</vmw:CoresPerSocket>
+      <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml" />
+    </ovf:Item>
+    <ovf:Item ns13:type="application/vnd.vmware.vcloud.rasdItem+xml" ns13:href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/memory">
+      <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+      <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Description>Memory Size</rasd:Description>
+      <rasd:ElementName>4096 MB of memory</rasd:ElementName>
+      <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:InstanceID>5</rasd:InstanceID>
+      <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Reservation>0</rasd:Reservation>
+      <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ResourceType>4</rasd:ResourceType>
+      <rasd:VirtualQuantity>4096</rasd:VirtualQuantity>
+      <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Weight>0</rasd:Weight>
+      <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml" />
+    </ovf:Item>
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" />
+    <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml" />
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml" />
+    <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml" />
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml" />
+    <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml" />
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml" />
+    <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml" />
+    <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml" />
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml" />
+    <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml" />
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml" />
+  </ovf:VirtualHardwareSection>
+  <ovf:OperatingSystemSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ovf:id="102" ns13:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="windows9Server64Guest" ns13:href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/operatingSystemSection/">
+    <ovf:Info>Specifies the operating system installed</ovf:Info>
+    <ovf:Description>Microsoft Windows Server 2016 (64-bit)</ovf:Description>
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml" />
+  </ovf:OperatingSystemSection>
+  <NetworkConnectionSection href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+    <ovf:Info>Specifies the available VM network connections</ovf:Info>
+    <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
+    <NetworkConnection needsCustomization="false" network="Localhost">
+      <NetworkConnectionIndex>0</NetworkConnectionIndex>
+      <IsConnected>true</IsConnected>
+      <MACAddress>00:50:56:01:01:2c</MACAddress>
+      <IpAddressAllocationMode>DHCP</IpAddressAllocationMode>
+      <NetworkAdapterType>PCNet32</NetworkAdapterType>
+    </NetworkConnection>
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" />
+  </NetworkConnectionSection>
+  <GuestCustomizationSection href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+    <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+    <Enabled>false</Enabled>
+    <ChangeSid>true</ChangeSid>
+    <VirtualMachineId>8dc9990c-a55a-418e-8e21-5942a20b93ef</VirtualMachineId>
+    <JoinDomainEnabled>false</JoinDomainEnabled>
+    <UseOrgSettings>false</UseOrgSettings>
+    <AdminPasswordEnabled>true</AdminPasswordEnabled>
+    <AdminPasswordAuto>true</AdminPasswordAuto>
+    <AdminAutoLogonEnabled>false</AdminAutoLogonEnabled>
+    <AdminAutoLogonCount>0</AdminAutoLogonCount>
+    <ResetPasswordRequired>false</ResetPasswordRequired>
+    <ComputerName>DatabseVM</ComputerName>
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" />
+  </GuestCustomizationSection>
+  <RuntimeInfoSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" ns13:href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/runtimeInfoSection">
+    <ovf:Info>Specifies Runtime info</ovf:Info>
+  </RuntimeInfoSection>
+  <SnapshotSection href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+    <ovf:Info>Snapshot information section</ovf:Info>
+  </SnapshotSection>
+  <DateCreated>2018-04-16T09:13:25.402+02:00</DateCreated>
+  <VAppScopedLocalId>af445e42-234d-41b2-9654-b36ac45ad71c</VAppScopedLocalId>
+  <VmCapabilities href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml" />
+    <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
+    <CpuHotAddEnabled>false</CpuHotAddEnabled>
+  </VmCapabilities>
+  <StorageProfile href="https://10.12.0.18/api/vdcStorageProfile/c87b2a7c-fcab-4f8a-bef3-3ece59366c38" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml" />
+</Vm>

--- a/lib/fog/vcloud_director/compute.rb
+++ b/lib/fog/vcloud_director/compute.rb
@@ -41,6 +41,8 @@ module Fog
       class DuplicateName < Fog::VcloudDirector::Errors::DuplicateName; end
       class TaskError < Fog::VcloudDirector::Errors::TaskError; end
 
+      class PreProcessingError < Fog::Errors::Error; end
+
       requires :vcloud_director_username, :vcloud_director_password, :vcloud_director_host
       recognizes :vcloud_director_api_version, :vcloud_director_show_progress, :path, :vcloud_token, :port
 

--- a/lib/fog/vcloud_director/generators/compute/reconfigure_vm.rb
+++ b/lib/fog/vcloud_director/generators/compute/reconfigure_vm.rb
@@ -1,0 +1,110 @@
+require 'fog/vcloud_director/generators/compute/compose_common'
+
+module Fog
+  module Generators
+    module Compute
+      module VcloudDirector
+        class ReconfigureVm
+          extend ComposeCommon
+
+          class << self
+            # Generates VM reconfiguration XML.
+            #
+            # @param [Nokogiri::Xml] current DOM representing current VM configuration.
+            # @param [Hash] options desired configuration. Please see examples-vm-reconfigure.md for details.
+            #
+            # @return [String] xml string, a modification of `current` input, with desired configurations applied.
+            def generate_xml(current, options)
+              current.root['name'] = options[:name] if options[:name]
+              current.at('Description').content = options[:description] if options[:description]
+              if options[:hardware]
+                update_virtual_hardware_section(current, options[:hardware])
+              else
+                # Remove entire VirtualHardwareSection if no hardware is modified.
+                # https://pubs.vmware.com/vcd-80/index.jsp#com.vmware.vcloud.api.sp.doc_90/GUID-4759B018-86C2-4C91-8176-3EC73CD7122B.html
+                current.at('//ovf:VirtualHardwareSection').remove
+              end
+              current.to_xml
+            end
+
+            # Apply desired hardware modifications to the original xml.
+            def update_virtual_hardware_section(xml, hardware)
+              update_virtual_hardware_section_item_mem(xml, **hardware[:memory]) if hardware[:memory]
+              update_virtual_hardware_section_item_cpu(xml, **hardware[:cpu]) if hardware[:cpu]
+              array_wrap(hardware[:disk]).reject { |d| d[:id].nil? || d[:capacity_mb] == -1 }.each { |disk| update_virtual_hardware_section_item_hdd(xml, **disk) }
+              array_wrap(hardware[:disk]).select { |d| d[:id].nil? }.each { |disk| add_virtual_hardware_section_item_hdd(xml, **disk) }
+              array_wrap(hardware[:disk]).select { |d| d[:capacity_mb] == -1 }.each { |disk| remove_virtual_hardware_section_item_hdd(xml, id: disk[:id]) }
+            end
+
+            def update_virtual_hardware_section_item_cpu(xml, num_cores: nil, cores_per_socket: nil, reservation: nil, limit: nil, weight: nil)
+              update_virtual_hardware_section_item(xml, :type => 3) do |item|
+                item.at('./rasd:VirtualQuantity').content = num_cores if num_cores
+                item.at('./rasd:Reservation').content = reservation if reservation
+                item.at('./rasd:Limit').content = limit if limit
+                item.at('./rasd:Weight').content = weight if weight
+                item.at('./vmw:CoresPerSocket').content = cores_per_socket if cores_per_socket
+              end
+            end
+
+            def update_virtual_hardware_section_item_mem(xml, quantity_mb: nil, reservation: nil, limit: nil, weight: nil)
+              update_virtual_hardware_section_item(xml, :type => 4) do |item|
+                item.at('./rasd:VirtualQuantity').content = quantity_mb if quantity_mb
+                item.at('./rasd:Reservation').content = reservation if reservation
+                item.at('./rasd:Limit').content = limit if limit
+                item.at('./rasd:Weight').content = weight if weight
+              end
+            end
+
+            def update_virtual_hardware_section_item_hdd(xml, id:, capacity_mb: nil, address: nil, type: nil, subtype: nil)
+              hdd_exists = update_virtual_hardware_section_item(xml, :type => 17, :id => id) do |item|
+                item.at('./rasd:AddressOnParent').content = address if address
+                item.at('./rasd:HostResource')['ns13:capacity'] = capacity_mb if capacity_mb
+                item.at('./rasd:HostResource')['ns13:busType'] = type if type
+                item.at('./rasd:HostResource')['ns13:busSubType'] = subtype if subtype
+              end
+              raise Fog::Compute::VcloudDirector::PreProcessingError.new("Error resizing disk: disk with id '#{id}' does not exist.") unless hdd_exists
+            end
+
+            def remove_virtual_hardware_section_item_hdd(xml, id:)
+              remove_virtual_hardware_section_item(xml, :type => 17, :id => id)
+            end
+
+            def add_virtual_hardware_section_item_hdd(xml, **disk)
+              disk[:id] = rand(10_000..100_000)
+              add_virtual_hardware_section_item(xml) do |section|
+                virtual_hardware_section_item_hdd(section, **disk)
+              end
+            end
+
+            def add_virtual_hardware_section_item(xml)
+              virtual_hardware = xml.at('//ovf:VirtualHardwareSection')
+              virtual_hardware.add_namespace_definition('vcloud', 'http://www.vmware.com/vcloud/v1.5')
+              Nokogiri::XML::Builder.with(virtual_hardware) do |section|
+                yield section
+              end
+              # Move the new item to satisfy vCloud's sorting requirements.
+              item = virtual_hardware.at('./ovf:Item[last()]').remove
+              virtual_hardware.at('./ovf:Item[last()]').after(item)
+            end
+
+            def update_virtual_hardware_section_item(xml, type:, id: nil)
+              condition = "rasd:ResourceType = '#{type}'"
+              condition += " and rasd:InstanceID = '#{id}'" if id
+              if (item = xml.at("//ovf:VirtualHardwareSection/ovf:Item[#{condition}]"))
+                yield item
+                true
+              else
+                false
+              end
+            end
+
+            def remove_virtual_hardware_section_item(xml, type:, id:)
+              item = xml.at("//ovf:VirtualHardwareSection/ovf:Item[rasd:ResourceType = '#{type}' and rasd:InstanceID = '#{id}']")
+              item.remove if item
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vcloud_director/models/compute/vm.rb
+++ b/lib/fog/vcloud_director/models/compute/vm.rb
@@ -172,15 +172,14 @@ module Fog
         
         # Reconfigure a VM using any of the options documented in
         # post_reconfigure_vm
-        def reconfigure(options)
-          options[:name] ||= name # name has to be sent
-          # Delete those things that are not changing for performance
-          [:cpu, :memory, :description].each do |k|
-            options.delete(k) if options.key? k and options[k] == attributes[k]
-          end
-          response = service.post_reconfigure_vm(id, options)
+        def reconfigure(options, current: nil)
+          # Fetch current XML.
+          current ||= service.get_vapp(id, :parser => 'xml').body
+          # Let post_reconfigure_vm apply modifications.
+          response = service.post_reconfigure_vm(id, current, options)
           service.process_task(response.body)
-          options.each {|k,v| attributes[k] = v}
+
+          # TODO: apply modifications on current VM instance.
         end
         
         def ready?

--- a/lib/fog/vcloud_director/requests/compute/post_reconfigure_vm.rb
+++ b/lib/fog/vcloud_director/requests/compute/post_reconfigure_vm.rb
@@ -1,8 +1,9 @@
+require 'fog/vcloud_director/generators/compute/reconfigure_vm'
+
 module Fog
   module Compute
     class VcloudDirector
       class Real
-        
         # Updates VM configuration.
         #
         # This operation is asynchronous and returns a task that you can
@@ -13,8 +14,6 @@ module Fog
         #
         # @option options [String] :name Change the VM's name [required].
         # @option options [String] :description VM description
-        # @option options [Integer] :cpu Number of CPUs
-        # @option options [Integer] :memory Memory in MB
         #
         # @return [Excon::Response]
         #   * body<~Hash>:
@@ -23,93 +22,14 @@ module Fog
         #
         # @see http://pubs.vmware.com/vcd-51/topic/com.vmware.vcloud.api.reference.doc_51/doc/operations/POST-ReconfigureVm.html
         # @since vCloud API version 5.1
-        def post_reconfigure_vm(id, options={})
-          
-          body = Nokogiri::XML::Builder.new do |xml|
-            attrs = {
-              :xmlns => 'http://www.vmware.com/vcloud/v1.5',
-              'xmlns:ovf' => 'http://schemas.dmtf.org/ovf/envelope/1',
-              'xmlns:rasd' => 'http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData',
-              :name => options[:name]
-            }
-            xml.Vm(attrs) do
-              xml.Description options[:description] if options[:description]
-              virtual_hardware_section(xml, options)
-            end
-          end.to_xml
-          
+        def post_reconfigure_vm(id, current, options)
           request(
-            :body    => body,
+            :body    => Fog::Generators::Compute::VcloudDirector::ReconfigureVm.generate_xml(current, options),
             :expects => 202,
             :headers => {'Content-Type' => 'application/vnd.vmware.vcloud.vm+xml'},
             :method  => 'POST',
             :parser  => Fog::ToHashDocument.new,
             :path    => "vApp/#{id}/action/reconfigureVm"
-          )
-        end
-        
-        private
-        
-        def virtual_hardware_section(xml, options)
-          return unless options[:cpu] or options[:memory]
-          xml['ovf'].VirtualHardwareSection do
-            xml['ovf'].Info 'Virtual Hardware Requirements'
-            cpu_section(xml, options[:cpu]) if options[:cpu]
-            memory_section(xml, options[:memory]) if options[:memory]
-          end
-        end
-        
-        def cpu_section(xml, cpu)
-          xml['ovf'].Item do
-            xml['rasd'].AllocationUnits 'hertz * 10 ^ 6'
-            xml['rasd'].InstanceID 5
-            xml['rasd'].ResourceType 3
-            xml['rasd'].VirtualQuantity cpu.to_i
-          end
-        end
-        
-        def memory_section(xml, memory)
-          xml['ovf'].Item do
-            xml['rasd'].AllocationUnits 'byte * 2^20'
-            xml['rasd'].InstanceID 6
-            xml['rasd'].ResourceType 4
-            xml['rasd'].VirtualQuantity memory.to_i
-          end
-        end
-        
-      end
-      
-      class Mock
-        def post_reconfigure_vm(id, options={})
-          unless data[:vms][id]
-            raise Fog::Compute::VcloudDirector::Forbidden.new(
-              'This operation is denied.'
-            )
-          end
-          
-          owner = {
-            :href => make_href("vApp/#{id}"),
-            :type => 'application/vnd.vmware.vcloud.vApp+xml'
-          }
-          task_id = enqueue_task(
-            "Updating Virtual Machine #{data[:vms][id][:name]}(#{id})", 'vappUpdateVm', owner,
-            :on_success => lambda do
-              data[:vms][id][:name] = options[:name]
-              data[:vms][id][:description] = options[:description] if options[:description]
-              data[:vms][id][:cpu_count] = options[:cpu] if options[:cpu]
-              data[:vms][id][:memory_in_mb] = options[:memory] if options[:memory]
-            end
-          )
-          body = {
-            :xmlns => xmlns,
-            :xmlns_xsi => xmlns_xsi,
-            :xsi_schemaLocation => xsi_schema_location,
-          }.merge(task_body(task_id))
-
-          Excon::Response.new(
-            :status => 202,
-            :headers => {'Content-Type' => "#{body[:type]};version=#{api_version}"},
-            :body => body
           )
         end
       end

--- a/spec/fixtures/vm.xml
+++ b/spec/fixtures/vm.xml
@@ -1,0 +1,419 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Vm xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" needsCustomization="false" deployed="false" status="8" name="Databasy Machiny" id="urn:vcloud:vm:8dc9990c-a55a-418e-8e21-5942a20b93ef" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef" type="application/vnd.vmware.vcloud.vm+xml">
+  <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+  <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+  <Link rel="screen:thumbnail" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/screen"/>
+  <Link rel="customizeAtNextPowerOn" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/action/customizeAtNextPowerOn"/>
+  <Link rel="up" href="https://10.12.0.18/api/vApp/vapp-fe8d013d-dd2f-4ac6-9e8a-3a4a18e0a62e" type="application/vnd.vmware.vcloud.vApp+xml"/>
+  <Description>DB Description</Description>
+  <Tasks>
+    <Task cancelRequested="false" endTime="2018-04-26T10:14:47.769+02:00" expiryTime="2018-07-25T10:14:42.767+02:00" operation="Updated Virtual Machine Databasy Machiny(8dc9990c-a55a-418e-8e21-5942a20b93ef)" operationName="vappUpdateVm" serviceNamespace="com.vmware.vcloud" startTime="2018-04-26T10:14:42.767+02:00" status="error" name="task" id="urn:vcloud:task:cff03716-2fce-4606-be1d-77e8a8180c85" href="https://10.12.0.18/api/task/cff03716-2fce-4606-be1d-77e8a8180c85" type="application/vnd.vmware.vcloud.task+xml">
+      <Owner href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef" name="Databasy Machiny" type="application/vnd.vmware.vcloud.vm+xml"/>
+      <Error majorErrorCode="500" message="[ 24e9f319-05bd-474e-bd1d-2b8bb3ea9c98 ] Unable to perform this action. Contact your cloud administrator." minorErrorCode="INTERNAL_SERVER_ERROR"/>
+      <User href="https://10.12.0.18/api/admin/user/4e1fe1f6-44a4-4ee8-a1ab-758d66a1e90d" name="system" type="application/vnd.vmware.admin.user+xml"/>
+      <Organization href="https://10.12.0.18/api/org/8f03aa58-b618-4c32-836b-dc6b612ed3a4" name="RedHat" type="application/vnd.vmware.vcloud.org+xml"/>
+      <Details>  [ 24e9f319-05bd-474e-bd1d-2b8bb3ea9c98 ] Unable to perform this action. Contact your cloud administr...</Details>
+    </Task>
+    <Task cancelRequested="false" endTime="2018-04-26T15:33:26.945+02:00" expiryTime="2018-07-25T15:33:24.212+02:00" operation="Updated Virtual Machine Databasy Machiny(8dc9990c-a55a-418e-8e21-5942a20b93ef)" operationName="vappUpdateVm" serviceNamespace="com.vmware.vcloud" startTime="2018-04-26T15:33:24.212+02:00" status="error" name="task" id="urn:vcloud:task:689049a4-890c-4074-aa30-cb20ca6105c6" href="https://10.12.0.18/api/task/689049a4-890c-4074-aa30-cb20ca6105c6" type="application/vnd.vmware.vcloud.task+xml">
+      <Owner href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef" name="Databasy Machiny" type="application/vnd.vmware.vcloud.vm+xml"/>
+      <Error majorErrorCode="500" message="[ 48c6327b-d661-4947-bc71-bc5009e3d60d ] Unable to perform this action. Contact your cloud administrator." minorErrorCode="INTERNAL_SERVER_ERROR"/>
+      <User href="https://10.12.0.18/api/admin/user/e0d6e74d-efde-49fe-b19f-ace7e55b68dd" name="redhat" type="application/vnd.vmware.admin.user+xml"/>
+      <Organization href="https://10.12.0.18/api/org/8f03aa58-b618-4c32-836b-dc6b612ed3a4" name="RedHat" type="application/vnd.vmware.vcloud.org+xml"/>
+      <Details>  [ 48c6327b-d661-4947-bc71-bc5009e3d60d ] Unable to perform this action. Contact your cloud administr...</Details>
+    </Task>
+    <Task cancelRequested="false" expiryTime="2018-07-25T15:36:23.440+02:00" operation="Updating Virtual Machine Databasy Machiny(8dc9990c-a55a-418e-8e21-5942a20b93ef)" operationName="vappUpdateVm" serviceNamespace="com.vmware.vcloud" startTime="2018-04-26T15:36:23.440+02:00" status="running" name="task" id="urn:vcloud:task:f4228017-9d2c-482b-b123-8360721e6f98" href="https://10.12.0.18/api/task/f4228017-9d2c-482b-b123-8360721e6f98" type="application/vnd.vmware.vcloud.task+xml">
+      <Link rel="task:cancel" href="https://10.12.0.18/api/task/f4228017-9d2c-482b-b123-8360721e6f98/action/cancel"/>
+      <Owner href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef" name="Databasy Machiny" type="application/vnd.vmware.vcloud.vm+xml"/>
+      <User href="https://10.12.0.18/api/admin/user/e0d6e74d-efde-49fe-b19f-ace7e55b68dd" name="redhat" type="application/vnd.vmware.admin.user+xml"/>
+      <Organization href="https://10.12.0.18/api/org/8f03aa58-b618-4c32-836b-dc6b612ed3a4" name="RedHat" type="application/vnd.vmware.vcloud.org+xml"/>
+      <Details/>
+    </Task>
+  </Tasks>
+  <ovf:VirtualHardwareSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ovf:transport="" ns13:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" ns13:href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/">
+    <ovf:Info>Virtual hardware requirements</ovf:Info>
+    <ovf:System>
+      <vssd:AutomaticRecoveryAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <vssd:AutomaticShutdownAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <vssd:AutomaticStartupAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <vssd:AutomaticStartupActionDelay xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <vssd:AutomaticStartupActionSequenceNumber xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <vssd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <vssd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <vssd:ConfigurationDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <vssd:ConfigurationFile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <vssd:ConfigurationID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <vssd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <vssd:CreationTime xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <vssd:Description xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+      <vssd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <vssd:InstanceID>0</vssd:InstanceID>
+      <vssd:LogDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <vssd:RecoveryFile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <vssd:SnapshotDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <vssd:SuspendDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <vssd:SwapFileDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <vssd:VirtualSystemIdentifier>Databasy Machiny</vssd:VirtualSystemIdentifier>
+      <vssd:VirtualSystemType>vmx-13</vssd:VirtualSystemType>
+    </ovf:System>
+    <ovf:Item>
+      <rasd:Address>00:50:56:01:01:2c</rasd:Address>
+      <rasd:AddressOnParent>0</rasd:AddressOnParent>
+      <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
+      <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Connection ns13:ipAddressingMode="DHCP" ns13:primaryNetworkConnection="true">Localhost</rasd:Connection>
+      <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Description>PCNet32 ethernet adapter on "Localhost"</rasd:Description>
+      <rasd:ElementName>Network adapter 0</rasd:ElementName>
+      <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:InstanceID>1</rasd:InstanceID>
+      <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ResourceSubType>PCNet32</rasd:ResourceSubType>
+      <rasd:ResourceType>10</rasd:ResourceType>
+      <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+    </ovf:Item>
+    <ovf:Item>
+      <rasd:Address>00:50:56:01:01:2d</rasd:Address>
+      <rasd:AddressOnParent>1</rasd:AddressOnParent>
+      <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
+      <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Connection ns13:ipAddressingMode="POOL" ns13:ipAddress="192.168.43.2" ns13:primaryNetworkConnection="false">RedHat Private network 43</rasd:Connection>
+      <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Description>E1000s ethernet adapter on "RedHat Private network 43"</rasd:Description>
+      <rasd:ElementName>Network adapter 1</rasd:ElementName>
+      <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:InstanceID>2</rasd:InstanceID>
+      <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ResourceSubType>E1000E</rasd:ResourceSubType>
+      <rasd:ResourceType>10</rasd:ResourceType>
+      <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+    </ovf:Item>
+    <ovf:Item>
+      <rasd:Address>0</rasd:Address>
+      <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Description>SCSI Controller</rasd:Description>
+      <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
+      <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:InstanceID>3</rasd:InstanceID>
+      <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ResourceSubType>lsilogicsas</rasd:ResourceSubType>
+      <rasd:ResourceType>6</rasd:ResourceType>
+      <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+    </ovf:Item>
+    <ovf:Item>
+      <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AddressOnParent>0</rasd:AddressOnParent>
+      <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Description>Hard disk</rasd:Description>
+      <rasd:ElementName>Hard disk 1</rasd:ElementName>
+      <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:HostResource ns13:storageProfileHref="https://10.12.0.18/api/vdcStorageProfile/c87b2a7c-fcab-4f8a-bef3-3ece59366c38" ns13:busType="6" ns13:busSubType="lsilogicsas" ns13:capacity="1024" ns13:iops="0" ns13:storageProfileOverrideVmDefault="false"/>
+      <rasd:InstanceID>2000</rasd:InstanceID>
+      <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Parent>3</rasd:Parent>
+      <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ResourceType>17</rasd:ResourceType>
+      <rasd:VirtualQuantity>1073741824</rasd:VirtualQuantity>
+      <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+      <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+    </ovf:Item>
+    <ovf:Item>
+      <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AddressOnParent>1</rasd:AddressOnParent>
+      <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Description>Hard disk</rasd:Description>
+      <rasd:ElementName>Hard disk 2</rasd:ElementName>
+      <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:HostResource ns13:storageProfileHref="https://10.12.0.18/api/vdcStorageProfile/c87b2a7c-fcab-4f8a-bef3-3ece59366c38" ns13:busType="6" ns13:busSubType="lsilogicsas" ns13:capacity="2048" ns13:iops="0" ns13:storageProfileOverrideVmDefault="false"/>
+      <rasd:InstanceID>2001</rasd:InstanceID>
+      <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Parent>3</rasd:Parent>
+      <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ResourceType>17</rasd:ResourceType>
+      <rasd:VirtualQuantity>2147483648</rasd:VirtualQuantity>
+      <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+      <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+    </ovf:Item>
+    <ovf:Item>
+      <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AddressOnParent>2</rasd:AddressOnParent>
+      <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Description>Hard disk</rasd:Description>
+      <rasd:ElementName>Hard disk 3</rasd:ElementName>
+      <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:HostResource ns13:storageProfileHref="https://10.12.0.18/api/vdcStorageProfile/c87b2a7c-fcab-4f8a-bef3-3ece59366c38" ns13:busType="6" ns13:busSubType="lsilogicsas" ns13:capacity="3072" ns13:iops="0" ns13:storageProfileOverrideVmDefault="false"/>
+      <rasd:InstanceID>2002</rasd:InstanceID>
+      <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Parent>3</rasd:Parent>
+      <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ResourceType>17</rasd:ResourceType>
+      <rasd:VirtualQuantity>3221225472</rasd:VirtualQuantity>
+      <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+      <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+    </ovf:Item>
+    <ovf:Item>
+      <rasd:Address>0</rasd:Address>
+      <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Description>IDE Controller</rasd:Description>
+      <rasd:ElementName>IDE Controller 0</rasd:ElementName>
+      <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:InstanceID>4</rasd:InstanceID>
+      <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ResourceType>5</rasd:ResourceType>
+      <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+    </ovf:Item>
+    <ovf:Item>
+      <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AddressOnParent>0</rasd:AddressOnParent>
+      <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+      <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Description>CD/DVD Drive</rasd:Description>
+      <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
+      <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:HostResource/>
+      <rasd:InstanceID>3000</rasd:InstanceID>
+      <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Parent>4</rasd:Parent>
+      <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ResourceType>15</rasd:ResourceType>
+      <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+    </ovf:Item>
+    <ovf:Item>
+      <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AddressOnParent>0</rasd:AddressOnParent>
+      <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+      <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Description>Floppy Drive</rasd:Description>
+      <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
+      <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:HostResource/>
+      <rasd:InstanceID>8000</rasd:InstanceID>
+      <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ResourceType>14</rasd:ResourceType>
+      <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+    </ovf:Item>
+    <ovf:Item ns13:type="application/vnd.vmware.vcloud.rasdItem+xml" ns13:href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/cpu">
+      <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+      <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Description>Number of Virtual CPUs</rasd:Description>
+      <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
+      <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:InstanceID>5</rasd:InstanceID>
+      <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Reservation>0</rasd:Reservation>
+      <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ResourceType>3</rasd:ResourceType>
+      <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
+      <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Weight>0</rasd:Weight>
+      <vmw:CoresPerSocket ovf:required="false">1</vmw:CoresPerSocket>
+      <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+    </ovf:Item>
+    <ovf:Item ns13:type="application/vnd.vmware.vcloud.rasdItem+xml" ns13:href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/memory">
+      <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+      <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Description>Memory Size</rasd:Description>
+      <rasd:ElementName>2048 MB of memory</rasd:ElementName>
+      <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:InstanceID>6</rasd:InstanceID>
+      <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Reservation>0</rasd:Reservation>
+      <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:ResourceType>4</rasd:ResourceType>
+      <rasd:VirtualQuantity>2048</rasd:VirtualQuantity>
+      <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      <rasd:Weight>0</rasd:Weight>
+      <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+    </ovf:Item>
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
+    <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+    <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+    <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+    <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+    <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+    <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+  </ovf:VirtualHardwareSection>
+  <ovf:OperatingSystemSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ovf:id="102" ns13:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="windows9Server64Guest" ns13:href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/operatingSystemSection/">
+    <ovf:Info>Specifies the operating system installed</ovf:Info>
+    <ovf:Description>Microsoft Windows Server 2016 (64-bit)</ovf:Description>
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
+  </ovf:OperatingSystemSection>
+  <NetworkConnectionSection href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+    <ovf:Info>Specifies the available VM network connections</ovf:Info>
+    <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
+    <NetworkConnection needsCustomization="false" network="Localhost">
+      <NetworkConnectionIndex>0</NetworkConnectionIndex>
+      <IsConnected>true</IsConnected>
+      <MACAddress>00:50:56:01:01:2c</MACAddress>
+      <IpAddressAllocationMode>DHCP</IpAddressAllocationMode>
+      <NetworkAdapterType>PCNet32</NetworkAdapterType>
+    </NetworkConnection>
+    <NetworkConnection needsCustomization="false" network="RedHat Private network 43">
+      <NetworkConnectionIndex>1</NetworkConnectionIndex>
+      <IpAddress>192.168.43.2</IpAddress>
+      <IsConnected>true</IsConnected>
+      <MACAddress>00:50:56:01:01:2d</MACAddress>
+      <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
+      <NetworkAdapterType>E1000E</NetworkAdapterType>
+    </NetworkConnection>
+  </NetworkConnectionSection>
+  <GuestCustomizationSection href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+    <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+    <Enabled>false</Enabled>
+    <ChangeSid>true</ChangeSid>
+    <VirtualMachineId>8dc9990c-a55a-418e-8e21-5942a20b93ef</VirtualMachineId>
+    <JoinDomainEnabled>false</JoinDomainEnabled>
+    <UseOrgSettings>false</UseOrgSettings>
+    <AdminPasswordEnabled>true</AdminPasswordEnabled>
+    <AdminPasswordAuto>true</AdminPasswordAuto>
+    <AdminAutoLogonEnabled>false</AdminAutoLogonEnabled>
+    <AdminAutoLogonCount>0</AdminAutoLogonCount>
+    <ResetPasswordRequired>false</ResetPasswordRequired>
+    <ComputerName>DatabseVM</ComputerName>
+  </GuestCustomizationSection>
+  <RuntimeInfoSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" ns13:href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/runtimeInfoSection">
+    <ovf:Info>Specifies Runtime info</ovf:Info>
+  </RuntimeInfoSection>
+  <SnapshotSection href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+    <ovf:Info>Snapshot information section</ovf:Info>
+  </SnapshotSection>
+  <DateCreated>2018-04-16T09:13:25.402+02:00</DateCreated>
+  <VAppScopedLocalId>af445e42-234d-41b2-9654-b36ac45ad71c</VAppScopedLocalId>
+  <VmCapabilities href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
+    <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
+    <CpuHotAddEnabled>false</CpuHotAddEnabled>
+  </VmCapabilities>
+  <StorageProfile href="https://10.12.0.18/api/vdcStorageProfile/c87b2a7c-fcab-4f8a-bef3-3ece59366c38" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+</Vm>

--- a/spec/vcloud_director/generators/compute/reconfigure_vm_spec.rb
+++ b/spec/vcloud_director/generators/compute/reconfigure_vm_spec.rb
@@ -1,0 +1,117 @@
+require './spec/spec_helper.rb'
+
+describe Fog::Generators::Compute::VcloudDirector::ReconfigureVm do
+  let(:current)  { Nokogiri::XML(File.read('./spec/fixtures/vm.xml')) }
+  let(:hardware) { {} }
+  let(:input)    { hardware ? { :hardware => hardware } : {} }
+  let(:output)   { Nokogiri::XML(Fog::Generators::Compute::VcloudDirector::ReconfigureVm.generate_xml(current, input)) }
+
+  describe 'reconfigure' do
+    describe 'name' do
+      let(:input) { { :name => 'new name' } }
+
+      it 'name' do
+        output.xpath('/*/@name').first.value.must_equal 'new name'
+      end
+    end
+
+    describe 'description' do
+      let(:input) { { :description => 'new description' } }
+
+      it 'description' do
+        output.at('Description').content.must_equal 'new description'
+      end
+    end
+
+    describe 'memory' do
+      let(:hardware) { { :memory => { :quantity_mb => 123 } } }
+
+      it 'memory' do
+        mem = output.xpath("//ovf:VirtualHardwareSection/ovf:Item[./rasd:ResourceType = '4']")
+        mem.xpath('./rasd:VirtualQuantity').text.must_equal '123'
+      end
+    end
+
+    describe 'cpu' do
+      let(:hardware) { { :cpu => { :num_cores => 8, :cores_per_socket => 4 } } }
+
+      it 'cpu' do
+        cpu = output.xpath("//ovf:VirtualHardwareSection/ovf:Item[./rasd:ResourceType = '3']")
+        cpu.xpath('./rasd:VirtualQuantity').text.must_equal '8'
+        cpu.xpath('./vmw:CoresPerSocket').text.must_equal '4'
+      end
+    end
+
+    describe 'disk' do
+      let(:hardware) { { :disk => disks } }
+
+      describe 'resize' do
+        let(:disks) { { :id => '2000', :capacity_mb => 123 } }
+
+        it 'resize' do
+          all_disks(output).count.must_equal 3
+          disk_by_id(output, '2000').at('./rasd:HostResource')['ns13:capacity'].must_equal '123'
+        end
+      end
+
+      describe 'resize nonexisting' do
+        let(:disks) { { :id => 'nonexisting', :capacity_mb => 123 } }
+
+        it 'resize nonexisting' do
+          -> { output }.must_raise Fog::Compute::VcloudDirector::PreProcessingError
+        end
+      end
+
+      describe 'remove' do
+        let(:disks) { { :id => '2000', :capacity_mb => -1 } }
+
+        it 'remove' do
+          all_disks(output).count.must_equal 2
+          disk_by_id(output, '2000').must_be_empty
+        end
+      end
+
+      describe 'remove nonexisting' do
+        let(:disks) { { :id => 'nonexisting', :capacity_mb => -1 } }
+
+        it 'remove nonexisting' do
+          all_disks(output).count.must_equal 3
+        end
+      end
+
+      describe 'add' do
+        let(:disks) { { :capacity_mb => 123 } }
+
+        it 'add' do
+          all_disks(output).count.must_equal 4
+          all_disks(output).last.at('./rasd:HostResource')['ns13:capacity'].must_equal '123'
+        end
+      end
+
+      describe 'resize, remove and add' do
+        let(:disks) do
+          [
+            { :id => '2000', :capacity_mb => 123 },
+            { :id => '2001', :capacity_mb => -1 },
+            { :capacity_mb => 321 }
+          ]
+        end
+
+        it 'resize, remove and add' do
+          all_disks(output).count.must_equal 3
+          disk_by_id(output, '2000').at('./rasd:HostResource')['ns13:capacity'].must_equal '123'
+          disk_by_id(output, '2001').must_be_empty
+          all_disks(output).last.at('./rasd:HostResource')['ns13:capacity'].must_equal '321'
+        end
+      end
+
+      def all_disks(xml)
+        xml.xpath("//ovf:VirtualHardwareSection/ovf:Item[./rasd:ResourceType = '17']")
+      end
+
+      def disk_by_id(xml, id)
+        all_disks(xml).xpath("//ovf:Item[./rasd:InstanceID = '#{id}']")
+      end
+    end
+  end
+end

--- a/spec/vcloud_director/requests/compute/basic_spec.rb
+++ b/spec/vcloud_director/requests/compute/basic_spec.rb
@@ -173,7 +173,6 @@ describe Fog::Compute::VcloudDirector::Real do
       { :req => :post_power_on_vapp, :args => %w(id) },
       { :req => :post_reboot_vapp, :args => %w(id) },
       { :req => :post_recompose_vapp, :args => ['id', { :vms_to_delete => [] }] },
-      { :req => :post_reconfigure_vm, :args => %w(id) },
       { :req => :post_remove_all_snapshots, :args => %w(id) },
       { :req => :post_reset_vapp, :args => %w(id) },
       { :req => :post_revert_snapshot, :args => %w(id) },


### PR DESCRIPTION
With this commit we enhance the `post_reconfigure_vm` function to actually support virtual hardware reconfiguration. vCloud requires **ALL** the hardware configuration to be sent even if we're only modifying a small piece of it. Current implementation of this call didn't respect this limitation which resulted in hardware disappearing. When we updated memory size, for example, all the VM disks vanished!

Syntax to configure hardware is now the very same to that of vapp template instantiation:

```
options = {
    :name        => 'DB VM',
    :description => 'Some Description',
    :hardware    => {
        :memory => { :quantity_mb => 4096 },
        :cpu    => { :num_cores => 4, :cores_per_socket => 1 },
        :disk   => [
            { :id => '2000', :capacity_mb => 5*1024 },
            { :id => '2001', :capacity_mb => -1 },
            { :capacity_mb => 1*1024 }
        ]
    }
}
service.post_reconfigure_vm('vm-id', xml, options)
```

Documentation attached.