### PR TITLE
Make Travis green again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,10 @@
 language: ruby
+script: "bundle exec rake test"
 sudo: false
+rvm:
+- 2.3.1
+- 2.4.2
 matrix:
   fast_finish: true
-  include:
-    - rvm: 2.0
-    - rvm: 2.1
-    - rvm: 2.2
-    - rvm: 2.3.0
-    - rvm: jruby-head
-  allow_failures:
-    - rvm: jruby-head
-
 notifications:
-  email: false
+email: false

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -1,13 +1,5 @@
-require "rake/testtask"
+require 'rake/testtask'
 
 Rake::TestTask.new do |t|
-  t.libs << "test"
-  t.pattern = File.join("test", "**", "test_*.rb")
-end
-
-namespace :test do
-  mock = ENV["FOG_MOCK"] || "true"
-  task :travis do
-    sh("export FOG_MOCK=#{mock} && bundle exec shindont")
-  end
+  t.pattern = 'spec/**/*_spec.rb'
 end


### PR DESCRIPTION
With this commit we configure Travis to run the new minitest unit tests instead of old tests that rely on MOCK=true variable.