### PR TITLE
Explicitly remove default setters prior overriding them

### DIFF
--- a/lib/fog/vcloud_director/models/compute/disk.rb
+++ b/lib/fog/vcloud_director/models/compute/disk.rb
@@ -17,6 +17,7 @@ module Fog
         attribute :bus_sub_type
         attribute :bus_type
 
+        remove_method :capacity=
         # TODO Virtual machine disk sizes may only be increased, not decreased.
         def capacity=(new_capacity)
           has_changed = ( capacity != new_capacity.to_i )

--- a/lib/fog/vcloud_director/models/compute/tag.rb
+++ b/lib/fog/vcloud_director/models/compute/tag.rb
@@ -7,6 +7,7 @@ module Fog
         identity  :id
         attribute :value
 
+        remove_method :value=
         def value=(new_value)
           has_changed = ( value != new_value )
           not_first_set = !value.nil?

--- a/lib/fog/vcloud_director/models/compute/vm.rb
+++ b/lib/fog/vcloud_director/models/compute/vm.rb
@@ -149,6 +149,7 @@ module Fog
           service.disks(:vm => self)
         end
 
+        remove_method :memory=
         def memory=(new_memory)
           has_changed = ( memory != new_memory.to_i )
           not_first_set = !memory.nil?
@@ -159,6 +160,7 @@ module Fog
           end
         end
 
+        remove_method :cpu=
         def cpu=(new_cpu)
           has_changed = ( cpu != new_cpu.to_i )
           not_first_set = !cpu.nil?


### PR DESCRIPTION
Using fog's utility function `attribute :<name>` creates both getter and setter function for the attribute. If we then decide to override setter, annoying warning appears:

```
warning: previous definition of cpu= was here
```

With this commit we explicitly remove default setter implementation prior overriding it to suppress the warning.