### PR TITLE
Differ VM from Template VM

### DIFF
--- a/lib/fog/vcloud_director/models/compute/template_vms.rb
+++ b/lib/fog/vcloud_director/models/compute/template_vms.rb
@@ -1,5 +1,5 @@
 require 'fog/core/collection'
-require 'fog/vcloud_director/models/compute/vm'
+require 'fog/vcloud_director/models/compute/template_vm'
 
 module Fog
   module Compute
@@ -13,7 +13,7 @@ module Fog
         attribute :vapp_template
 
 
-        def get_single_vm(vm_id)
+        def get_single_template_vm(vm_id)
           item = service.get_template_vm(vm_id).body
           return nil unless item
           new(item[:vm])

--- a/lib/fog/vcloud_director/requests/compute/get_template_vm.rb
+++ b/lib/fog/vcloud_director/requests/compute/get_template_vm.rb
@@ -13,7 +13,7 @@ module Fog
         #   * body<~Hash>:
         #
         # @see #get_vapp
-        def get_vm(id)
+        def get_template_vm(id)
           request(
             :expects    => 200,
             :idempotent => true,
@@ -22,52 +22,6 @@ module Fog
             :path       => "vAppTemplate/#{id}"
           )
         end
-      end
-      class Mock
-        def get_vm(id)
-          vapp = get_vapp(id).body
-          vm = parse_vapp_to_vm(vapp)
-          body = {:type => vapp[:type], :vm => vm}
-          Excon::Response.new(
-            :status => 200,
-            :headers => {'Content-Type' => "#{body[:type]};version=#{api_version}"},
-            :body => body
-          )
-        end
-        
-        # Mock equivalent of Fog::Parsers::Compute::VcloudDirector::Vm
-        def parse_vapp_to_vm(vapp)
-          parser = Fog::Parsers::Compute::VcloudDirector::Vm.new
-          vm = vapp.select {|k| [:href, :name, :status, :type].include? k}
-          network = vapp[:NetworkConnectionSection]
-          vm.merge({
-            :id => vapp[:href].split('/').last,
-            :status => parser.human_status(vapp[:status]),
-            :ip_address => network[:NetworkConnection][:IpAddress],
-            :description => vapp[:Description],
-            :cpu => get_hardware(vapp, 3),
-            :memory => get_hardware(vapp, 4),
-            :disks => get_disks(vapp),
-            :links => [vapp[:GuestCustomizationSection][:Link]],
-          })
-        end
-        
-        def get_hardware(vapp, resource_type)
-          hardware = vapp[:"ovf:VirtualHardwareSection"][:"ovf:Item"]
-          item = hardware.find {|h| h[:"rasd:ResourceType"].to_i == resource_type}
-          if item and item.key? :"rasd:VirtualQuantity"
-            item[:"rasd:VirtualQuantity"].to_i
-          else
-            nil
-          end
-        end
-        
-        def get_disks(vapp)
-          hardware = vapp[:"ovf:VirtualHardwareSection"][:"ovf:Item"]
-          disks = hardware.select {|h| h[:"rasd:ResourceType"].to_i == 17}
-          disks.map {|d| {d[:"rasd:ElementName"] => d[:"rasd:HostResource"][:ns12_capacity].to_i}}
-        end
-        
       end
     end
   end

--- a/lib/fog/vcloud_director/requests/compute/get_template_vms.rb
+++ b/lib/fog/vcloud_director/requests/compute/get_template_vms.rb
@@ -23,19 +23,6 @@ module Fog
           )
         end
       end
-      class Mock
-        def get_vms(id)
-          vapptemplate = get_vapp(id).body
-          parser = Fog::Parsers::Compute::VcloudDirector::Vms.new
-          vms  = vapp[:Children][:Vm].map {|child| parse_vapp_to_vm(child) }
-          body = {:type => vapp[:type], :vms => vms}
-          Excon::Response.new(
-            :status => 200,
-            :headers => {'Content-Type' => "#{body[:type]};version=#{api_version}"},
-            :body => body
-          )
-        end
-      end
     end
   end
 end

--- a/lib/fog/vcloud_director/requests/compute/get_vm.rb
+++ b/lib/fog/vcloud_director/requests/compute/get_vm.rb
@@ -23,52 +23,6 @@ module Fog
           )
         end
       end
-      class Mock
-        def get_vm(id)
-          vapp = get_vapp(id).body
-          vm = parse_vapp_to_vm(vapp)
-          body = {:type => vapp[:type], :vm => vm}
-          Excon::Response.new(
-            :status => 200,
-            :headers => {'Content-Type' => "#{body[:type]};version=#{api_version}"},
-            :body => body
-          )
-        end
-        
-        # Mock equivalent of Fog::Parsers::Compute::VcloudDirector::Vm
-        def parse_vapp_to_vm(vapp)
-          parser = Fog::Parsers::Compute::VcloudDirector::Vm.new
-          vm = vapp.select {|k| [:href, :name, :status, :type].include? k}
-          network = vapp[:NetworkConnectionSection]
-          vm.merge({
-            :id => vapp[:href].split('/').last,
-            :status => parser.human_status(vapp[:status]),
-            :ip_address => network[:NetworkConnection][:IpAddress],
-            :description => vapp[:Description],
-            :cpu => get_hardware(vapp, 3),
-            :memory => get_hardware(vapp, 4),
-            :disks => get_disks(vapp),
-            :links => [vapp[:GuestCustomizationSection][:Link]],
-          })
-        end
-        
-        def get_hardware(vapp, resource_type)
-          hardware = vapp[:"ovf:VirtualHardwareSection"][:"ovf:Item"]
-          item = hardware.find {|h| h[:"rasd:ResourceType"].to_i == resource_type}
-          if item and item.key? :"rasd:VirtualQuantity"
-            item[:"rasd:VirtualQuantity"].to_i
-          else
-            nil
-          end
-        end
-        
-        def get_disks(vapp)
-          hardware = vapp[:"ovf:VirtualHardwareSection"][:"ovf:Item"]
-          disks = hardware.select {|h| h[:"rasd:ResourceType"].to_i == 17}
-          disks.map {|d| {d[:"rasd:ElementName"] => d[:"rasd:HostResource"][:ns12_capacity].to_i}}
-        end
-        
-      end
     end
   end
 end


### PR DESCRIPTION
With this commit we make explicit difference between VM and Template VM to avoid redefinition of same method names which makes it import-order agnostic... Not anymore.