### PR TITLE
Remove unused variables all over the project

### DIFF
--- a/lib/fog/vcloud_director/generators/compute/org_vdc_network.rb
+++ b/lib/fog/vcloud_director/generators/compute/org_vdc_network.rb
@@ -11,7 +11,7 @@ module Fog
           end
 
           def generate_xml
-            body = Nokogiri::XML::Builder.new do
+            Nokogiri::XML::Builder.new do
               attrs = {
                 :xmlns => 'http://www.vmware.com/vcloud/v1.5',
                 :name  => options[:name]

--- a/lib/fog/vcloud_director/generators/compute/vapp.rb
+++ b/lib/fog/vcloud_director/generators/compute/vapp.rb
@@ -12,7 +12,6 @@ module Fog
           end
 
           def generate_xml
-            attrs = @attrs
             Nokogiri::XML::Builder.new do
               VApp('xmlns' => 'http://www.vmware.com/vcloud/v1.5',
                    'name' => name

--- a/lib/fog/vcloud_director/requests/compute/delete_vapp.rb
+++ b/lib/fog/vcloud_director/requests/compute/delete_vapp.rb
@@ -26,7 +26,7 @@ module Fog
       end
       class Mock
         def delete_vapp(id)
-          unless vapp = data[:vapps][id]
+          unless data[:vapps][id]
             raise Fog::Compute::VcloudDirector::Forbidden.new(
               'This operation is denied.'
             )

--- a/lib/fog/vcloud_director/requests/compute/get_lease_settings_section_vapp.rb
+++ b/lib/fog/vcloud_director/requests/compute/get_lease_settings_section_vapp.rb
@@ -27,7 +27,7 @@ module Fog
 
           type = 'application/vnd.vmware.vcloud.leaseSettingsSection+xml'
 
-          unless vapp = data[:vapps][id]
+          unless data[:vapps][id]
             raise Fog::Compute::VcloudDirector::Forbidden.new(
               'This operation is denied.'
             )

--- a/lib/fog/vcloud_director/requests/compute/get_vapp_metadata.rb
+++ b/lib/fog/vcloud_director/requests/compute/get_vapp_metadata.rb
@@ -60,7 +60,7 @@ module Fog
         def get_metadata_entries(metadata, id)
           metadata_entries = []
 
-          for key, value in metadata do
+          for key, _ in metadata do
           metadata_entries << {:type=>"application/vnd.vmware.vcloud.metadata.value+xml",
               :href=>make_href("vApp/#{id}/metadata/#{key}"),
               :Link=>

--- a/lib/fog/vcloud_director/requests/compute/get_vapp_owner.rb
+++ b/lib/fog/vcloud_director/requests/compute/get_vapp_owner.rb
@@ -26,7 +26,7 @@ module Fog
 
           type = 'application/vnd.vmware.vcloud.owner+xml'
 
-          unless vapp = data[:vapps][id]
+          unless data[:vapps][id]
             raise Fog::Compute::VcloudDirector::Forbidden.new(
               'This operation is denied.'
             )

--- a/lib/fog/vcloud_director/requests/compute/get_vms.rb
+++ b/lib/fog/vcloud_director/requests/compute/get_vms.rb
@@ -26,7 +26,6 @@ module Fog
       class Mock
         def get_vms(id)
           vapp = get_vapp(id).body
-          parser = Fog::Parsers::Compute::VcloudDirector::Vms.new
           vms  = vapp[:Children][:Vm].map {|child| parse_vapp_to_vm(child) }
           body = {:type => vapp[:type], :vms => vms}
           Excon::Response.new(

--- a/lib/fog/vcloud_director/requests/compute/instantiate_vapp_template.rb
+++ b/lib/fog/vcloud_director/requests/compute/instantiate_vapp_template.rb
@@ -110,7 +110,7 @@ module Fog
               'No such template.'
             )
           end
-          unless vdc = data[:vdcs][options[:vdc_id]]
+          unless data[:vdcs][options[:vdc_id]]
             raise Fog::Compute::VcloudDirector::Forbidden.new(
               'No such VDC.'
             )

--- a/lib/fog/vcloud_director/requests/compute/post_power_on_vapp.rb
+++ b/lib/fog/vcloud_director/requests/compute/post_power_on_vapp.rb
@@ -33,7 +33,7 @@ module Fog
       end
       class Mock
         def post_power_on_vapp(id)
-          unless vapp = data[:vapps][id]
+          unless data[:vapps][id]
             raise Fog::Compute::VcloudDirector::Forbidden.new(
               'This operation is denied.'
             )
@@ -65,7 +65,7 @@ module Fog
             :body => body
           )
         end
-        end
+      end
     end
   end
 end

--- a/lib/fog/vcloud_director/requests/compute/post_reconfigure_vm.rb
+++ b/lib/fog/vcloud_director/requests/compute/post_reconfigure_vm.rb
@@ -81,7 +81,7 @@ module Fog
       
       class Mock
         def post_reconfigure_vm(id, options={})
-          unless vm = data[:vms][id]
+          unless data[:vms][id]
             raise Fog::Compute::VcloudDirector::Forbidden.new(
               'This operation is denied.'
             )

--- a/lib/fog/vcloud_director/requests/compute/post_update_vapp_metadata.rb
+++ b/lib/fog/vcloud_director/requests/compute/post_update_vapp_metadata.rb
@@ -49,7 +49,7 @@ module Fog
       end
       class Mock
         def post_update_vapp_metadata(id, metadata={})
-          unless vm = data[:vms][id]
+          unless data[:vms][id]
             raise Fog::Compute::VcloudDirector::Forbidden.new(
               'This operation is denied.'
             )

--- a/lib/fog/vcloud_director/requests/compute/put_cpu.rb
+++ b/lib/fog/vcloud_director/requests/compute/put_cpu.rb
@@ -53,7 +53,7 @@ EOF
       class Mock
 
         def put_cpu(id, num_cpus)
-          unless vm = data[:vms][id]
+          unless data[:vms][id]
             raise Fog::Compute::VcloudDirector::Forbidden.new(
               'This operation is denied.'
             )

--- a/lib/fog/vcloud_director/requests/compute/put_memory.rb
+++ b/lib/fog/vcloud_director/requests/compute/put_memory.rb
@@ -53,7 +53,7 @@ EOF
       class Mock
 
         def put_memory(id, memory)
-          unless vm = data[:vms][id]
+          unless data[:vms][id]
             raise Fog::Compute::VcloudDirector::Forbidden.new(
               'This operation is denied.'
             )

--- a/lib/fog/vcloud_director/requests/compute/put_network_connection_system_section_vapp.rb
+++ b/lib/fog/vcloud_director/requests/compute/put_network_connection_system_section_vapp.rb
@@ -118,7 +118,7 @@ module Fog
       end
       class Mock
         def put_network_connection_system_section_vapp(id, options={})
-          unless vm = data[:vms][id]
+          unless data[:vms][id]
             raise Fog::Compute::VcloudDirector::Forbidden.new(
               'This operation is denied.'
             )

--- a/lib/fog/vcloud_director/requests/compute/put_vm.rb
+++ b/lib/fog/vcloud_director/requests/compute/put_vm.rb
@@ -37,7 +37,7 @@ module Fog
       class Mock
 
         def put_vm(id, name, options)
-          unless vm = data[:vms][id]
+          unless data[:vms][id]
             raise Fog::Compute::VcloudDirector::Forbidden.new(
               'This operation is denied.'
             )


### PR DESCRIPTION
When we run minitests, many warnings appear complaining about unused variables. With this commit we remove those occurences to avoid warnings.