### PR TITLE
Turn off verbose ruby warnings for Travis

### DIFF
--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -2,4 +2,5 @@ require 'rake/testtask'
 
 Rake::TestTask.new do |t|
   t.pattern = 'spec/**/*_spec.rb'
+  t.warning = false
 end


### PR DESCRIPTION
After quite some research (!) about why so many warnings are raised complaining about redefining method:

```
warning: previous definition of <method> was here
```

it turns out that it's the way fog core works! Fog simply redefines function everytime object is invoked, see [here](https://github.com/fog/fog-core/blob/master/lib/fog/core/attributes/integer.rb#L9-L13) . Tones of similar warnings are being issued when using fog/openstack gem as well therefore we conclude that nothing can be done about it. With this commit we therefore suppress verbose warnings to make Travis log readable again.

An issuse was opened on fog core to discuss this bug: https://github.com/fog/fog-core/issues/235.