### PR TITLE
Explicitly use non-mocked class

### DIFF
--- a/spec/vcr_spec_helper.rb
+++ b/spec/vcr_spec_helper.rb
@@ -20,7 +20,7 @@ def vcr_service
   end
 
   @vcr_service ||= VCR.use_cassette('authentication') do
-    Fog::Compute::VcloudDirector.new(
+    Fog::Compute::VcloudDirector::Real.new(
       :vcloud_director_username      => username,
       :vcloud_director_password      => password,
       :vcloud_director_host          => hostname,


### PR DESCRIPTION
With this commit we resolve strange error that fog core occasionally used mocked classes instead real ones, even if value of FOG_MOCK variable hasn't changed. Since we're not using fog mocks anymore at all, we just hard-code it to always use real classes.