### PR TITLE
Parse VM's vapp_id using VM xml

### DIFF
--- a/lib/fog/vcloud_director/models/compute/vm.rb
+++ b/lib/fog/vcloud_director/models/compute/vm.rb
@@ -7,7 +7,6 @@ module Fog
         identity  :id
 
         attribute :vapp_id
-        attribute :vapp_name # TODO(miha-plesko) remove this attribute because value is not included in XML.
         attribute :name
         attribute :type
         attribute :description

--- a/lib/fog/vcloud_director/parsers/compute/vm.rb
+++ b/lib/fog/vcloud_director/parsers/compute/vm.rb
@@ -11,7 +11,7 @@ module Fog
             @in_operating_system = false
             @in_children = false
             @resource_type = nil
-            @response = { :vm => { :ip_address => '', :description => '' } }
+            @response = { :vm => initialize_vm }
             @links = []
           end
 

--- a/lib/fog/vcloud_director/parsers/compute/vm_parser_helper.rb
+++ b/lib/fog/vcloud_director/parsers/compute/vm_parser_helper.rb
@@ -3,6 +3,13 @@ module Fog
     module Compute
       module VcloudDirector
         module VmParserHelper
+          def initialize_vm
+            {
+              :vapp_id     => nil,
+              :ip_address  => '',
+              :description => '',
+            }
+          end
 
           def parse_end_element(name, vm)
             case name
@@ -53,10 +60,12 @@ module Fog
             when 'Connection'
               @current_network_connection = extract_attributes(attributes)
             when 'Link'
+              # Extract vapp_id from 'up' link.
+              vm[:vapp_id] = attr_value('href', attributes).to_s.split('/').last if attr_value('type', attributes) == 'application/vnd.vmware.vcloud.vApp+xml'
+
               @links << extract_attributes(attributes)
             end
           end
-
         end
       end
     end

--- a/lib/fog/vcloud_director/parsers/compute/vms.rb
+++ b/lib/fog/vcloud_director/parsers/compute/vms.rb
@@ -8,7 +8,7 @@ module Fog
           include VmParserHelper
 
           def reset
-            @vm = { :ip_address => '', :description => '' }
+            @vm = initialize_vm
             @in_operating_system = false
             @in_children = false
             @resource_type = nil

--- a/spec/common_assertions.rb
+++ b/spec/common_assertions.rb
@@ -1,7 +1,7 @@
 def expect_vm(vm, vapp_id:, name:, status:, deployed:, os:, ip:, cpu:, cores_per_socket:, mem:, num_hdds:, num_nics:)
   vm.must_be_instance_of Fog::Compute::VcloudDirector::Vm
   vm.type.must_equal 'application/vnd.vmware.vcloud.vm+xml'
-  # vm.vapp_id.must_equal vapp_id # TODO(miha-plesko) update parser to fetch this value from single VM response as well.
+  vm.vapp_id.must_equal vapp_id
   vm.name.must_equal name
   vm.description.must_equal ''
   vm.href.must_include '/api/vApp/vm-'


### PR DESCRIPTION
With this commit we parse vapp_id attribute from the vm xml. Default value is set to `nil` in order to avoid infinite loop problem (see previous commit for more info).

Also, with this commit we centralize VM initialization instead of duplicating the code everywhere.