### PR TITLE
Make sure vApp reloads when necessery

### DIFF
--- a/lib/fog/vcloud_director/models/compute/vapp.rb
+++ b/lib/fog/vcloud_director/models/compute/vapp.rb
@@ -21,10 +21,12 @@ module Fog
           # Instead simple Array we rather store as Collection in order to provide common interface e.g.
           #    vapp.vms.all
           #    vapp.vms.get_by_name
-          @vms = Fog::Compute::VcloudDirector::Vms.new(
-            :vapp    => self,
-            :service => kwargs[:service]
-          ).with_item_list(Array(kwargs.delete(:vms)))
+          if (vms = kwargs.delete(:vms))
+            @vms = Fog::Compute::VcloudDirector::Vms.new(
+              :vapp    => self,
+              :service => kwargs[:service]
+            ).with_item_list(Array(vms))
+          end
 
           super(*args, **kwargs)
         end

--- a/lib/fog/vcloud_director/parsers/compute/vapp.rb
+++ b/lib/fog/vcloud_director/parsers/compute/vapp.rb
@@ -9,12 +9,9 @@ module Fog
 
           def reset
             @response = @vapp = {
-              :description     => '',
-              :owner           => nil,
-              :lease_settings  => nil,
-              :network_section => nil,
-              :network_config  => nil,
-              :vms             => []
+              :lease_settings  => 'not-implemented',
+              :network_section => 'not-implemented',
+              :network_config  => 'not-implemented'
             }
             @in_sections = false
             @parsing_vm  = false
@@ -43,6 +40,7 @@ module Fog
               @vapp[:deployed] = @vapp[:deployed] == 'true'
             when 'LeaseSettingsSection' # this is the first of the sections
               @in_sections = true
+              @vapp[:description] ||= '' # if description wasn't parsed by now, then vApp has empty description
             when 'User'
               @vapp[:owner] = attr_value('href', attributes).to_s.split('/').last
             when 'Vm'
@@ -60,6 +58,7 @@ module Fog
               @vapp[:maintenance] = value == 'true'
             when 'Vm'
               @parsing_vm = false
+              @vapp[:vms] ||= []
               @vapp[:vms] << @curr_vm
             end
           end

--- a/spec/vcloud_director/models/compute/vapps_spec.rb
+++ b/spec/vcloud_director/models/compute/vapps_spec.rb
@@ -30,9 +30,9 @@ describe Fog::Compute::VcloudDirector::Vapps do
         :description => '',
         :deployed    => false,
         :status      => 'off',
-        :lease       => nil,
-        :net_section => nil,
-        :net_config  => nil,
+        :lease       => 'not-implemented',
+        :net_section => 'not-implemented',
+        :net_config  => 'not-implemented',
         :owner       => 'e0d6e74d-efde-49fe-b19f-ace7e55b68dd',
         :maintenance => false,
         :num_vms     => 2


### PR DESCRIPTION
When vApp is parsed from the VDC summary XML it contains no other data than vApp id and name. So we mustn't initialize vms to empty array in order to trigger API request when this attribute is accessed. Similar goes with vApp description: we now only set it to empty string when we're certain that we're parsing the full-blown vApp XML.