### PR TITLE
Explicitly require vapp_template instead vapp after update

### DIFF
--- a/lib/fog/vcloud_director/models/compute/vapp_templates.rb
+++ b/lib/fog/vcloud_director/models/compute/vapp_templates.rb
@@ -1,4 +1,4 @@
-require 'fog/vcloud_director/models/compute/vapp'
+require 'fog/vcloud_director/models/compute/vapp_template'
 
 module Fog
   module Compute


### PR DESCRIPTION
There was major error long living in code: incorrect file was required. Error was only discovered now because in most cases the correct file was required already elsewhere in code.

With this commit we now make sure correct file is imported.

Fixes: https://github.com/xlab-si/fog-vcloud-director/issues/33