### PR TITLE
Make sure import order is always the same

### DIFF
--- a/lib/fog/vcloud_director.rb
+++ b/lib/fog/vcloud_director.rb
@@ -9,7 +9,7 @@ require 'fog/vcloud_director/core'
 require 'fog/vcloud_director/query'
 require 'fog/vcloud_director/compute'
 
-Dir[File.join(File.dirname(__FILE__), 'vcloud_director', 'generators', '**', '*.rb')].each {|file| require file }
-Dir[File.join(File.dirname(__FILE__), 'vcloud_director', 'models', '**', '*.rb')].each {|file| require file }
-Dir[File.join(File.dirname(__FILE__), 'vcloud_director', 'parsers', '**', '*.rb')].each {|file| require file }
-Dir[File.join(File.dirname(__FILE__), 'vcloud_director', 'requests', '**', '*.rb')].each {|file| require file }
+Dir[File.join(File.dirname(__FILE__), 'vcloud_director', 'generators', '**', '*.rb')].sort.each {|file| require file }
+Dir[File.join(File.dirname(__FILE__), 'vcloud_director', 'models', '**', '*.rb')].sort.each {|file| require file }
+Dir[File.join(File.dirname(__FILE__), 'vcloud_director', 'parsers', '**', '*.rb')].sort.each {|file| require file }
+Dir[File.join(File.dirname(__FILE__), 'vcloud_director', 'requests', '**', '*.rb')].sort.each {|file| require file }


### PR DESCRIPTION
With this commit we make sure that filenames are sorted prior importing them in order to guarantee exact same behavior for all users.