### PR TITLE
Support for NIC reconfiguration

### DIFF
--- a/docs/examples-vm-reconfigure.md
+++ b/docs/examples-vm-reconfigure.md
@@ -37,3 +37,86 @@ service.post_reconfigure_vm(
 **NOTE**: If you omit `:hardware` key from options, then reconfiguration request will be
 simplified by omitting entire VirtualHardwareSection from payload XML. So please prefer
 omitting the `:hardware` key over passing `:hardware => {}` in order to reduce network load. 
+
+## Network Connection Reconfiguration Example
+This example demonstrates basic NIC connection customization that allows you to modify what
+vApp network is each VM's NIC connected to, among with other NIC options.
+
+```ruby
+service = Fog::Compute::VcloudDirector.new(...)
+
+# Obtain nokogiri-parsed XML representation of VM.
+xml = service.get_vapp('vm-8dc9990c-a55a-418e-8e21-5942a20b93ef', :parser => 'xml').body
+
+# Update NIC#0.
+options = {    
+    :networks => [
+        {
+          :idx       => 0, # pick NIC#0 to apply below modifications to
+           
+          :new_idx   => 5,                   # assign new NIC virtual index to 5 (instead 0) 
+          :name      => 'Localhost',         # plug NIC to vApp network called 'Localhost'
+          :mac       => '11:22:33:44:55:66', # set NIC MAC address
+          :mode      => 'MANUAL',            # set NIC IP address allocation mode
+          :ip        => '1.2.3.4',           # set NIC IP address
+          :type      => 'PCNet32',           # set NIC adapter type
+          :primary   => true,                # make this NIC primary
+          :needs     => true,                # mark NIC as 'needs customization'
+          :connected => true                 # mark NIC as connected
+        }
+    ]
+}
+
+# Actually perform customization.
+service.post_reconfigure_vm(
+  'vm-8dc9990c-a55a-418e-8e21-5942a20b93ef',
+  xml,
+  options
+)
+``` 
+
+### Unplugging NIC
+Please use vCloud's reserved network name `'none'` to unplug NIC from all vApp networks.
+NIC will be marked as disconnected automatically:
+
+```ruby
+options = {    
+    :networks => [
+        {
+          :idx  => 0,
+          :name => 'none'
+        }
+    ]
+}
+```
+
+### Removing NIC
+Please set `:new_idx => -1` to remove NIC from the VM.
+
+```ruby
+options = {    
+    :networks => [
+        {
+          :idx     => 0,
+          :new_idx => -1
+        }
+    ]
+}
+```
+
+### Adding a New NIC
+Please set `:idx => nil` to add a new NIC and specify its index with `:new_idx` key. You can
+specify any other NIC options as well, of course, like what vApp network to plug the new NIC
+to:
+
+```ruby
+options = {    
+    :networks => [
+        {
+          :idx     => nil,
+          :new_idx => 1,
+          :name    => 'Localhost'
+        }
+    ]
+}
+```

--- a/lib/fog/vcloud_director/generators/compute/compose_common.rb
+++ b/lib/fog/vcloud_director/generators/compute/compose_common.rb
@@ -251,6 +251,19 @@ module Fog
             return 'bridged' unless mode && mode != 'isolated'
             mode
           end
+
+          def network_section_nic(xml, new_idx:, name: 'none', mac: nil, ip: nil, connected: true, mode: 'DHCP', type: nil, needs: nil)
+            attr = { :network => name }
+            attr[:needsCustomization] = needs unless needs.nil?
+            xml.NetworkConnection(attr) do
+              xml.NetworkConnectionIndex(new_idx) if new_idx
+              xml.IpAddress(ip) unless ip.nil?
+              xml.IsConnected(connected) unless connected.nil?
+              xml.MACAddress(mac) if mac
+              xml.IpAddressAllocationMode(mode) if mode
+              xml.NetworkAdapterType(type) if type
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
With this commit we add support for updating, adding and removing NICs (network interface cards) from a VM. Reconfiguration options have been extended to support `:networks` subsection:

```ruby
options = {
  :networks => [
    {
      :idx       => 0, # pick NIC#0 to apply below modifications to

      :new_idx   => 5,                   # assign new NIC virtual index to 5 (instead 0)
      :name      => 'Localhost',         # plug NIC to vApp network called 'Localhost'
      :mac       => '11:22:33:44:55:66', # set NIC MAC address
      :mode      => 'MANUAL',            # set NIC IP address allocation mode
      :ip        => '1.2.3.4',           # set NIC IP address
      :type      => 'PCNet32',           # set NIC adapter type
      :primary   => true,                # make this NIC primary
      :needs     => true,                # mark NIC as 'needs customization'
      :connected => true                 # mark NIC as connected
    }
 ]
}
```

A new NIC can be added by passing `:idx => nil` while existing NIC can be removed by passing `:new_idx => -1`, see documentation for details.