### PR TITLE
Insert missing XML elements when not present

### DIFF
--- a/spec/fixtures/empty_vm.xml
+++ b/spec/fixtures/empty_vm.xml
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Vm xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" needsCustomization="true" nestedHypervisorEnabled="false" deployed="false" status="8" name="Databasy Machiny" id="urn:vcloud:vm:8dc9990c-a55a-418e-8e21-5942a20b93ef" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef" type="application/vnd.vmware.vcloud.vm+xml">
+  <Link rel="power:powerOn" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/power/action/powerOn" />
+  <Link rel="deploy" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml" />
+  <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef" type="application/vnd.vmware.vcloud.vm+xml" />
+  <Link rel="remove" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef" />
+  <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/metadata" type="application/vnd.vmware.vcloud.metadata+xml" />
+  <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/productSections/" type="application/vnd.vmware.vcloud.productSections+xml" />
+  <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/metrics/historic" type="application/vnd.vmware.vcloud.metrics.historicUsageSpec+xml" />
+  <Link rel="metrics" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/metrics/historic" type="application/vnd.vmware.vcloud.metrics.historicUsageSpec+xml" />
+  <Link rel="screen:thumbnail" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/screen" />
+  <Link rel="media:insertMedia" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/media/action/insertMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml" />
+  <Link rel="media:ejectMedia" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/media/action/ejectMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml" />
+  <Link rel="disk:attach" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/disk/action/attach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml" />
+  <Link rel="disk:detach" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/disk/action/detach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml" />
+  <Link rel="enable" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/action/enableNestedHypervisor" />
+  <Link rel="customizeAtNextPowerOn" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/action/customizeAtNextPowerOn" />
+  <Link rel="snapshot:create" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml" />
+  <Link rel="reconfigureVm" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/action/reconfigureVm" name="Databasy Machiny" type="application/vnd.vmware.vcloud.vm+xml" />
+  <Link rel="up" href="https://10.12.0.18/api/vApp/vapp-fe8d013d-dd2f-4ac6-9e8a-3a4a18e0a62e" type="application/vnd.vmware.vcloud.vApp+xml" />
+  <Description>DB Description</Description>
+  <Tasks>
+    <Task cancelRequested="false" endTime="2018-05-21T15:31:14.265+02:00" expiryTime="2018-08-19T15:31:12.287+02:00" operation="Updated Virtual Machine Databasy Machiny(8dc9990c-a55a-418e-8e21-5942a20b93ef)" operationName="vappUpdateVm" serviceNamespace="com.vmware.vcloud" startTime="2018-05-21T15:31:12.287+02:00" status="error" name="task" id="urn:vcloud:task:b867159a-f0cd-4aec-8994-d59cc4110b6e" href="https://10.12.0.18/api/task/b867159a-f0cd-4aec-8994-d59cc4110b6e" type="application/vnd.vmware.vcloud.task+xml">
+      <Owner href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef" name="Databasy Machiny" type="application/vnd.vmware.vcloud.vm+xml" />
+      <Error majorErrorCode="400" message="[ 9c3afab2-07d4-440b-98ae-52824014c259 ] The VCD entity network &quot;RedHat Private network 42 3&quot; does not exist." minorErrorCode="BAD_REQUEST" />
+      <User href="https://10.12.0.18/api/admin/user/e0d6e74d-efde-49fe-b19f-ace7e55b68dd" name="redhat" type="application/vnd.vmware.admin.user+xml" />
+      <Organization href="https://10.12.0.18/api/org/8f03aa58-b618-4c32-836b-dc6b612ed3a4" name="RedHat" type="application/vnd.vmware.vcloud.org+xml" />
+      <Details>[ 9c3afab2-07d4-440b-98ae-52824014c259 ] The VCD entity network "RedHat Private network 42 3" does n...</Details>
+    </Task>
+  </Tasks>
+  <ovf:VirtualHardwareSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ovf:transport="" ns13:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" ns13:href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/">
+    <ovf:Info>Virtual hardware requirements</ovf:Info>
+    <ovf:System>
+      <vssd:AutomaticRecoveryAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:AutomaticShutdownAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:AutomaticStartupAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:AutomaticStartupActionDelay xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:AutomaticStartupActionSequenceNumber xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:ConfigurationDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:ConfigurationFile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:ConfigurationID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:CreationTime xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:Description xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+      <vssd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:InstanceID>0</vssd:InstanceID>
+      <vssd:LogDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:RecoveryFile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:SnapshotDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:SuspendDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:SwapFileDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <vssd:VirtualSystemIdentifier>Databasy Machiny</vssd:VirtualSystemIdentifier>
+      <vssd:VirtualSystemType>vmx-13</vssd:VirtualSystemType>
+    </ovf:System>
+    <ovf:Item>
+      <rasd:Address>0</rasd:Address>
+      <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Description>IDE Controller</rasd:Description>
+      <rasd:ElementName>IDE Controller 0</rasd:ElementName>
+      <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:InstanceID>1</rasd:InstanceID>
+      <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ResourceType>5</rasd:ResourceType>
+      <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+    </ovf:Item>
+    <ovf:Item>
+      <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AddressOnParent>0</rasd:AddressOnParent>
+      <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+      <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Description>CD/DVD Drive</rasd:Description>
+      <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
+      <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:HostResource />
+      <rasd:InstanceID>3000</rasd:InstanceID>
+      <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Parent>1</rasd:Parent>
+      <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ResourceType>15</rasd:ResourceType>
+      <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+    </ovf:Item>
+    <ovf:Item>
+      <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AddressOnParent>0</rasd:AddressOnParent>
+      <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+      <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Description>Floppy Drive</rasd:Description>
+      <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
+      <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:HostResource />
+      <rasd:InstanceID>8000</rasd:InstanceID>
+      <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ResourceType>14</rasd:ResourceType>
+      <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+    </ovf:Item>
+    <ovf:Item ns13:type="application/vnd.vmware.vcloud.rasdItem+xml" ns13:href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/cpu">
+      <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+      <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Description>Number of Virtual CPUs</rasd:Description>
+      <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
+      <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:InstanceID>2</rasd:InstanceID>
+      <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Reservation>0</rasd:Reservation>
+      <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ResourceType>3</rasd:ResourceType>
+      <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
+      <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Weight>0</rasd:Weight>
+      <vmw:CoresPerSocket ovf:required="false">1</vmw:CoresPerSocket>
+      <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml" />
+    </ovf:Item>
+    <ovf:Item ns13:type="application/vnd.vmware.vcloud.rasdItem+xml" ns13:href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/memory">
+      <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+      <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Description>Memory Size</rasd:Description>
+      <rasd:ElementName>1024 MB of memory</rasd:ElementName>
+      <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:InstanceID>3</rasd:InstanceID>
+      <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Reservation>0</rasd:Reservation>
+      <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:ResourceType>4</rasd:ResourceType>
+      <rasd:VirtualQuantity>1024</rasd:VirtualQuantity>
+      <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+      <rasd:Weight>0</rasd:Weight>
+      <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml" />
+    </ovf:Item>
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" />
+    <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml" />
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml" />
+    <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml" />
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml" />
+    <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml" />
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml" />
+    <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml" />
+    <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml" />
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml" />
+    <Link rel="down" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml" />
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml" />
+  </ovf:VirtualHardwareSection>
+  <ovf:OperatingSystemSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ovf:id="102" ns13:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="windows9Server64Guest" ns13:href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/operatingSystemSection/">
+    <ovf:Info>Specifies the operating system installed</ovf:Info>
+    <ovf:Description>Microsoft Windows Server 2016 (64-bit)</ovf:Description>
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml" />
+  </ovf:OperatingSystemSection>
+  <NetworkConnectionSection href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+    <ovf:Info>Specifies the available VM network connections</ovf:Info>
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" />
+  </NetworkConnectionSection>
+  <GuestCustomizationSection href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+    <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+    <Enabled>false</Enabled>
+    <ChangeSid>true</ChangeSid>
+    <VirtualMachineId>8dc9990c-a55a-418e-8e21-5942a20b93ef</VirtualMachineId>
+    <JoinDomainEnabled>false</JoinDomainEnabled>
+    <UseOrgSettings>false</UseOrgSettings>
+    <AdminPasswordEnabled>true</AdminPasswordEnabled>
+    <AdminPasswordAuto>true</AdminPasswordAuto>
+    <AdminAutoLogonEnabled>false</AdminAutoLogonEnabled>
+    <AdminAutoLogonCount>0</AdminAutoLogonCount>
+    <ResetPasswordRequired>false</ResetPasswordRequired>
+    <ComputerName>DatabseVM</ComputerName>
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" />
+  </GuestCustomizationSection>
+  <RuntimeInfoSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" ns13:href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/runtimeInfoSection">
+    <ovf:Info>Specifies Runtime info</ovf:Info>
+  </RuntimeInfoSection>
+  <SnapshotSection href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+    <ovf:Info>Snapshot information section</ovf:Info>
+  </SnapshotSection>
+  <DateCreated>2018-04-16T09:13:25.402+02:00</DateCreated>
+  <VAppScopedLocalId>af445e42-234d-41b2-9654-b36ac45ad71c</VAppScopedLocalId>
+  <VmCapabilities href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
+    <Link rel="edit" href="https://10.12.0.18/api/vApp/vm-8dc9990c-a55a-418e-8e21-5942a20b93ef/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml" />
+    <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
+    <CpuHotAddEnabled>false</CpuHotAddEnabled>
+  </VmCapabilities>
+  <StorageProfile href="https://10.12.0.18/api/vdcStorageProfile/c87b2a7c-fcab-4f8a-bef3-3ece59366c38" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml" />
+</Vm>


### PR DESCRIPTION
With this commit we make sure fog doesn't crash when NetworkConnectionSection is sparse (contains no all elements). We're better off inserting those missing elements than crashing.